### PR TITLE
fix(deviations): split monolithic test cases and fix partial-revert race

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -13,7 +13,7 @@ on:
         type: string
 env:
   PY_VER: "3.10"
-  GO_VER: "1.23.3"
+  GO_VER: "1.25.9"
 
 jobs:
   latest-versions:

--- a/tests/01-crs/connection-profiles/conn_profile_srl_gnmi_json.yaml
+++ b/tests/01-crs/connection-profiles/conn_profile_srl_gnmi_json.yaml
@@ -1,0 +1,13 @@
+apiVersion: inv.sdcio.dev/v1alpha1
+kind: TargetConnectionProfile
+metadata:
+  name: test-srl-gnmi-json
+  namespace: default
+  labels:
+    scdio.dev/env: ci-test
+spec:
+  port: 57400
+  protocol: gnmi
+  encoding: JSON
+  skipVerify: true
+  insecure: false

--- a/tests/01-crs/discovery-rule/discovery_srl_gnmi_srl1_proto_onchange.yaml
+++ b/tests/01-crs/discovery-rule/discovery_srl_gnmi_srl1_proto_onchange.yaml
@@ -1,0 +1,24 @@
+apiVersion: inv.sdcio.dev/v1alpha1
+kind: DiscoveryRule
+metadata:
+  name: dr-srl-gnmi-srl1-proto-onchange
+  namespace: default
+spec:
+  period: 1m
+  concurrentScans: 2
+  addresses:
+  - address: 172.21.0.11
+    hostName: srl1
+  discoveryProfile:
+    credentials: srl.nokia.sdcio.dev
+    connectionProfiles:
+    - test-srl-gnmi-proto
+  targetConnectionProfiles:
+  - credentials: srl.nokia.sdcio.dev
+    connectionProfile: test-srl-gnmi-proto
+    syncProfile: test-srl-gnmi-onchange
+  targetTemplate:
+    labels:
+      sdcio.dev/region: eu-west
+      scdio.dev/env: ci-test
+      sdcio.dev/device: srl

--- a/tests/01-crs/discovery-rule/discovery_srl_gnmi_srl2_jsonietf_onchange.yaml
+++ b/tests/01-crs/discovery-rule/discovery_srl_gnmi_srl2_jsonietf_onchange.yaml
@@ -1,0 +1,24 @@
+apiVersion: inv.sdcio.dev/v1alpha1
+kind: DiscoveryRule
+metadata:
+  name: dr-srl-gnmi-srl2-jsonietf-onchange
+  namespace: default
+spec:
+  period: 1m
+  concurrentScans: 2
+  addresses:
+  - address: 172.21.0.12
+    hostName: srl2
+  discoveryProfile:
+    credentials: srl.nokia.sdcio.dev
+    connectionProfiles:
+    - test-srl-gnmi-jsonietf
+  targetConnectionProfiles:
+  - credentials: srl.nokia.sdcio.dev
+    connectionProfile: test-srl-gnmi-jsonietf
+    syncProfile: test-srl-gnmi-onchange-jsonietf
+  targetTemplate:
+    labels:
+      sdcio.dev/region: eu-west
+      scdio.dev/env: ci-test
+      sdcio.dev/device: srl

--- a/tests/01-crs/discovery-rule/discovery_srl_gnmi_srl3_jsonietf_onchange.yaml
+++ b/tests/01-crs/discovery-rule/discovery_srl_gnmi_srl3_jsonietf_onchange.yaml
@@ -1,0 +1,24 @@
+apiVersion: inv.sdcio.dev/v1alpha1
+kind: DiscoveryRule
+metadata:
+  name: dr-srl-gnmi-srl3-jsonietf-onchange
+  namespace: default
+spec:
+  period: 1m
+  concurrentScans: 2
+  addresses:
+  - address: 172.21.0.13
+    hostName: srl3
+  discoveryProfile:
+    credentials: srl.nokia.sdcio.dev
+    connectionProfiles:
+    - test-srl-gnmi-jsonietf
+  targetConnectionProfiles:
+  - credentials: srl.nokia.sdcio.dev
+    connectionProfile: test-srl-gnmi-jsonietf
+    syncProfile: test-srl-gnmi-onchange-jsonietf
+  targetTemplate:
+    labels:
+      sdcio.dev/region: eu-west
+      scdio.dev/env: ci-test
+      sdcio.dev/device: srl

--- a/tests/01-crs/discovery-rule/discovery_sros_gnmi_sr2_onchange.yaml
+++ b/tests/01-crs/discovery-rule/discovery_sros_gnmi_sr2_onchange.yaml
@@ -1,0 +1,24 @@
+apiVersion: inv.sdcio.dev/v1alpha1
+kind: DiscoveryRule
+metadata:
+  name: dr-sros-gnmi-sr2-onchange
+  namespace: default
+spec:
+  period: 1m
+  concurrentScans: 2
+  addresses:
+  - address: 172.21.1.12
+    hostName: sr2
+  discoveryProfile:
+    credentials: sros.nokia.sdcio.dev
+    connectionProfiles:
+    - test-sros-gnmi
+  targetConnectionProfiles:
+  - credentials: sros.nokia.sdcio.dev
+    connectionProfile: test-sros-gnmi
+    syncProfile: test-sros-gnmi-onchange-json
+  targetTemplate:
+    labels:
+      sdcio.dev/region: eu-west
+      scdio.dev/env: ci-test
+      sdcio.dev/device: sros

--- a/tests/01-crs/sync-profiles/sync_profile_srl_gnmi_get.yaml
+++ b/tests/01-crs/sync-profiles/sync_profile_srl_gnmi_get.yaml
@@ -14,4 +14,4 @@ spec:
     - /
     mode: get
     encoding: PROTO
-    interval: "30s"
+    interval: "5s"

--- a/tests/01-crs/sync-profiles/sync_profile_srl_gnmi_onchange_json.yaml
+++ b/tests/01-crs/sync-profiles/sync_profile_srl_gnmi_onchange_json.yaml
@@ -1,7 +1,7 @@
 apiVersion: inv.sdcio.dev/v1alpha1
 kind: TargetSyncProfile
 metadata:
-  name: test-sros-netconf-getconfig
+  name: test-srl-gnmi-onchange-json
   namespace: default
 spec:
   buffer: 0
@@ -9,10 +9,8 @@ spec:
   validate: true
   sync:
   - name: config
-    protocol: netconf
-    port: 830
+    protocol: gnmi
     paths:
     - /
-    mode: get
-    encoding: CONFIG
-    interval: "5s"
+    mode: onChange
+    encoding: JSON

--- a/tests/01-crs/sync-profiles/sync_profile_srl_gnmi_onchange_jsonietf.yaml
+++ b/tests/01-crs/sync-profiles/sync_profile_srl_gnmi_onchange_jsonietf.yaml
@@ -1,7 +1,7 @@
 apiVersion: inv.sdcio.dev/v1alpha1
 kind: TargetSyncProfile
 metadata:
-  name: test-sros-netconf-getconfig
+  name: test-srl-gnmi-onchange-jsonietf
   namespace: default
 spec:
   buffer: 0
@@ -9,10 +9,8 @@ spec:
   validate: true
   sync:
   - name: config
-    protocol: netconf
-    port: 830
+    protocol: gnmi
     paths:
     - /
-    mode: get
-    encoding: CONFIG
-    interval: "5s"
+    mode: onChange
+    encoding: JSON_IETF

--- a/tests/01-crs/sync-profiles/sync_profile_sros_gnmi.yaml
+++ b/tests/01-crs/sync-profiles/sync_profile_sros_gnmi.yaml
@@ -14,4 +14,4 @@ spec:
     - /configure
     mode: get
     encoding: JSON
-    interval: "30s"
+    interval: "5s"

--- a/tests/01-crs/sync-profiles/sync_profile_sros_gnmi_onchange.yaml
+++ b/tests/01-crs/sync-profiles/sync_profile_sros_gnmi_onchange.yaml
@@ -1,7 +1,7 @@
 apiVersion: inv.sdcio.dev/v1alpha1
 kind: TargetSyncProfile
 metadata:
-  name: test-sros-gnmi-onchange
+  name: test-sros-gnmi-onchange-json
   namespace: default
 spec:
   buffer: 0
@@ -12,5 +12,5 @@ spec:
     protocol: gnmi
     paths:
     - /configure
-    mode: get
-    encoding: PROTO
+    mode: onChange
+    encoding: JSON

--- a/tests/02-crud/11-sros-create-delete.robot
+++ b/tests/02-crud/11-sros-create-delete.robot
@@ -9,6 +9,7 @@ Resource            ../Keywords/targets.robot
 Resource            ../Keywords/config.robot
 Resource            ../Keywords/yq.robot
 Resource            ../Keywords/gnmic.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
@@ -16,143 +17,57 @@ Suite Teardown      Run Keyword    Cleanup
 *** Variables ***
 # sr1 = netconf ; sr2 = gNMI get
 
-@{SDCIO_SROS_NODES}     sr1    sr2
+@{SDCIO_SROS_NODES}           sr1    sr2
 @{SDCIO_CONFIGSET_INTENTS}    intent1    intent2
-@{SDCIO_CONFIG_INTENTS}    intent3    intent4
-&{intents}        intent1=vprn123    intent2=vprn234    intent3=vprn789    intent4=vprn987
-${options}    --insecure -e JSON
-${filter}    "configure/service/vprn"
+@{SDCIO_CONFIG_INTENTS}       intent3    intent4
+&{intents}                    intent1=vprn123    intent2=vprn234    intent3=vprn789    intent4=vprn987
+${options}                    --insecure -e JSON
+${filter}                     "configure/service/vprn"
+${eventual_timeout}           2min
+${retry}                      2s
+${orphan_reconcile_grace}     30s
+${INTENT_TARGET_CACHE}        ${None}    # populated by Initialize Intent Target Cache in Setup
 
 *** Test Cases ***
-Create and Verify Config(Set)
-    [Documentation]    Verify Config(Set) resources are created and verify on SROS nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create And Verify intent1
+    [Tags]    create
+    Create And Verify Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # Apply the Config(Set) Intent
-        Log    Create Config(Set) for intent ${intent}
-        ${rc}    ${output}=    kubectl apply    ${CURDIR}/input/sros/${intent}-sros.yaml
-        
-        # Verify the Config(Set) is transitioning to a ready state in k8s
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            Log    Verify ConfigSet ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    ConfigSet Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-sros
-        ELSE
-            Log    Verify Config ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Config Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-sros
-        END
+Create And Verify intent2
+    [Tags]    create
+    Create And Verify Intent    intent2
 
-        # Verify the Config is applied on the SROS nodes
-        Log   Verify Config(Set) ${intent} on ${SDCIO_SROS_NODES}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Note, as the gnmic output is not properly JSON formatted, we need to save the gnmic output initially to a file, 
-            # to be able to compare it in consecutive runs.
-            # ONLY UNCOMMENT THE FOLLOWING LINES IF YOU NEED TO UPDATE THE EXPECTED OUTPUT
-            # START BLOCK
-            # ${gnmicoutput} =    Get Config from node
-            # ...    ${node}
-            # ...    ${options}
-            # ...    ${SROS_USERNAME}
-            # ...    ${SROS_PASSWORD}
-            # ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            # ...    ${filter}
-            # Save JSON to file    ${gnmicoutput}    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
-            # END BLOCK
+Create And Verify intent3
+    [Tags]    create
+    Create And Verify Intent    intent3
 
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+Create And Verify intent4
+    [Tags]    create
+    Create And Verify Intent    intent4
 
-            ${compare} =    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-            
-            Should Be True      ${compare}
-        END
-    END
+Delete And Verify intent1
+    [Tags]    delete
+    Delete And Verify Intent    intent1
 
-Delete and Verify Config(Set)
-    [Documentation]    Delete Config(Set) resources are deleted in k8s and on SROS nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Delete And Verify intent2
+    [Tags]    delete
+    Delete And Verify Intent    intent2
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            # Delete the ConfigSet Intent
-            Log    Delete ConfigSet for intent ${intent}
-            ${rc}    ${output}=    Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-sros
-    
-            # Verify the ConfigSet is gone in k8s
-            Log    Verify ConfigSet ${intent} is gone on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Run Keyword And Expect Error    *
-            ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}-sros
-        ELSE
-            # Delete the Config Intent
-            Log    Delete Config for intent ${intent}
-            ${rc}    ${output} =    Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-sros
-            
-            # Verify the Config is gone in k8s
-            Log    Verify Config ${intent} is gone on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Run Keyword And Expect Error    *
-            ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}-sros
-        END
-        
-        # Verify the Config is gone on the SROS nodes
-        Log   Verify Config ${intent} on ${SDCIO_SROS_NODES}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${filter}
+Delete And Verify intent3
+    [Tags]    delete
+    Delete And Verify Intent    intent3
 
-            # [HT] Fix, remove None values from output list, before checking if it's empty
-            ${output} =   Evaluate    [i for i in ${output} if i]
-            Should Be Empty    ${output}
-        END
-    END
+Delete And Verify intent4
+    [Tags]    delete
+    Delete And Verify Intent    intent4
+
+Delete Config Intent with orphan policy keeps device config - intent3
+    [Tags]    orphan    delete    config
+    Verify Orphan Deletion Policy For Intent    intent3
+
+Delete ConfigSet with orphan policy keeps device config on all targets - intent1
+    [Tags]    orphan    delete    configset
+    Verify Orphan Deletion Policy For ConfigSet    intent1
 
 *** Keywords ***
 Setup
@@ -162,6 +77,7 @@ Setup
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    2min    10s    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"
+    Initialize Intent Target Cache    ${CURDIR}/input/sros    -sros
 
 Cleanup
     Run    echo 'cleanup executed'
@@ -170,11 +86,121 @@ Cleanup
 
 DeleteAll
     Log    Deleting all SROS Config
-    FOR  ${node}    IN    @{SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{SDCIO_SROS_NODES}
         Delete Config from node
         ...    ${node}
         ...    ${options}
         ...    ${SROS_USERNAME}
         ...    ${SROS_PASSWORD}
         ...    "/configure/service/vprn[service-name=*]"
+    END
+
+Verify Intent Config On Node
+    [Arguments]    ${intent}    ${node}    ${expected_file}
+    @{expectedoutput} =    Load JSON from file    ${expected_file}
+    ${compare} =    Get Config from node and Verify Intent
+    ...    ${node}
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+    ...    ${expectedoutput}
+    ...    ${filter}
+    Should Be True    ${compare}
+
+Verify Intent Config Deleted On Node
+    [Arguments]    ${intent}    ${node}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+    ...    ${filter}
+    ${output} =    Evaluate    [i for i in ${output} if i]
+    Should Be Empty    ${output}
+
+Create And Verify Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    ${EMPTY}    ${CURDIR}/input/sros    -sros
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Verify Intent Config On Node    ${intent}    ${node}    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+    END
+
+Delete And Verify Intent
+    [Arguments]    ${intent}
+    Delete Intent From K8s    ${intent}    -sros
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}
+    END
+
+Verify Orphan Deletion Policy For Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    ${EMPTY}    ${CURDIR}/input/sros    -sros
+    kubectl patch    config    ${intent}-sros    '{"spec": {"lifecycle": {"deletionPolicy": "orphan"}}}'
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Config Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    ${intent}-sros
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Verify Intent Config On Node    ${intent}    ${node}    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+    END
+    Delete Intent From K8s    ${intent}    -sros
+    Sleep    ${orphan_reconcile_grace}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node
+        ...    ${intent}
+        ...    ${node}
+        ...    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+    END
+    FOR    ${node}    IN    @{nodes}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}
+    END
+
+Verify Orphan Deletion Policy For ConfigSet
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    ${EMPTY}    ${CURDIR}/input/sros    -sros
+    kubectl patch    configset    ${intent}-sros    '{"spec": {"lifecycle": {"deletionPolicy": "orphan"}}}'
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    ConfigSet Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    ${intent}-sros
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Verify Intent Config On Node    ${intent}    ${node}    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+    END
+    Delete Intent From K8s    ${intent}    -sros
+    Sleep    ${orphan_reconcile_grace}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node
+        ...    ${intent}
+        ...    ${node}
+        ...    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+    END
+    FOR    ${node}    IN    @{nodes}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}
     END

--- a/tests/02-crud/12-srl-create-delete.robot
+++ b/tests/02-crud/12-srl-create-delete.robot
@@ -9,146 +9,71 @@ Resource            ../Keywords/targets.robot
 Resource            ../Keywords/config.robot
 Resource            ../Keywords/yq.robot
 Resource            ../Keywords/gnmic.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
 
 *** Variables ***
-# sr1 = netconf ; sr2 = gNMI get
-
-@{SDCIO_SRL_NODES}     srl1    srl2    srl3
+@{SDCIO_SRL_NODES}            srl1    srl2    srl3
 @{SDCIO_CONFIGSET_INTENTS}    intent1    intent2
-@{SDCIO_CONFIG_INTENTS}    intent3    intent4    intent5
-&{intents}        intent1=vrf1    intent2=vrf2    intent3=vrf3    intent4=vrf4    intent5=vrf5
-&{intentsinterfaces}        intent1=ethernet-1/1    intent2=ethernet-1/2    intent3=ethernet-1/3    intent4=ethernet-1/4    intent5=ethernet-1/5
-${options}    --skip-verify -e PROTO
+@{SDCIO_CONFIG_INTENTS}       intent3    intent4    intent5
+&{intents}                    intent1=vrf1    intent2=vrf2    intent3=vrf3    intent4=vrf4    intent5=vrf5
+&{intentsinterfaces}          intent1=ethernet-1/1    intent2=ethernet-1/2    intent3=ethernet-1/3    intent4=ethernet-1/4    intent5=ethernet-1/5
+${options}                    --skip-verify -e PROTO
+${eventual_timeout}           2min
+${retry}                      2s
+${orphan_reconcile_grace}     30s
+${INTENT_TARGET_CACHE}        ${None}    # populated by Initialize Intent Target Cache in Setup
 
 *** Test Cases ***
-Create and Verify Config(Set)
-    [Documentation]    Verify Config(Set) resources are created and verify on SRL nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create And Verify intent1
+    [Tags]    create
+    Create And Verify Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # Apply the Config(Set) Intent
-        Log    Create Config(Set) for intent ${intent}
-        ${rc}    ${output}=    kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml
+Create And Verify intent2
+    [Tags]    create
+    Create And Verify Intent    intent2
 
-        # Verify the ConfigSet is transitioning to a ready state in k8s
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            Log    Verify ConfigSet ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    ConfigSet Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-srl
-        ELSE
-            Log    Verify Config ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Config Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-srl
-        END
+Create And Verify intent3
+    [Tags]    create
+    Create And Verify Intent    intent3
 
-        # Verify the Config is applied on the SRL nodes
-        Log   Verify Config(Set) ${intent} on ${SDCIO_SRL_NODES}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Note, as the gnmic output is not properly JSON formatted, we need to save the gnmic output initially to a file, 
-            # to be able to compare it in consecutive runs.
-            # ONLY UNCOMMENT THE FOLLOWING LINE IF YOU NEED TO UPDATE THE EXPECTED OUTPUT
-            # START BLOCK
-            # ${gnmicoutput} =    Get Config from node
-            # ...    ${node}
-            # ...    ${options}
-            # ...    ${SRL_USERNAME}
-            # ...    ${SRL_PASSWORD}
-            # ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            # Save JSON to file    ${gnmicoutput}    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
-            # END BLOCK
+Create And Verify intent4
+    [Tags]    create
+    Create And Verify Intent    intent4
 
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+Create And Verify intent5
+    [Tags]    create
+    Create And Verify Intent    intent5
 
-            ${compare} =    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-            
-            Should Be True      ${compare}
-        END
-    END
+Delete And Verify intent1
+    [Tags]    delete
+    Delete And Verify Intent    intent1
 
-Delete and Verify Config(Set)
-    [Documentation]    Delete Config(Set) resources are deleted in k8s and on SRL nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Delete And Verify intent2
+    [Tags]    delete
+    Delete And Verify Intent    intent2
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            # Delete the ConfigSet Intent
-            Log    Delete ConfigSet for intent ${intent}
-            ${rc}    ${output}=    Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-srl
-            
-            # Verify the ConfigSet is gone in k8s
-            Log    Verify ConfigSet ${intent} is gone on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Run Keyword And Expect Error    *
-            ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}-srl
-        ELSE
-            # Delete the Config Intent
-            Log    Delete Config for intent ${intent}
-            ${rc}    ${output} =    Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-srl
-    
-            # Verify the Config is gone in k8s
-            Log    Verify Config ${intent} is gone on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Run Keyword And Expect Error    *
-            ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}-srl
-        END
+Delete And Verify intent3
+    [Tags]    delete
+    Delete And Verify Intent    intent3
 
-        ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-        # Verify the Config is gone on the SRL nodes
-        Log   Verify Config ${intent} on ${SDCIO_SRL_NODES}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
+Delete And Verify intent4
+    [Tags]    delete
+    Delete And Verify Intent    intent4
 
-    	    Should Be Empty    ${output}
-        END
-    END
+Delete And Verify intent5
+    [Tags]    delete
+    Delete And Verify Intent    intent5
+
+Delete Config Intent with orphan policy keeps device config - intent3
+    [Tags]    orphan    delete    config
+    Verify Orphan Deletion Policy For Intent    intent3
+
+Delete ConfigSet with orphan policy keeps device config on all targets - intent1
+    [Tags]    orphan    delete    configset
+    Verify Orphan Deletion Policy For ConfigSet    intent1
 
 *** Keywords ***
 Setup
@@ -156,6 +81,7 @@ Setup
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
         Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
+    Initialize Intent Target Cache    ${CURDIR}/input/srl    -srl
 
 Cleanup
     Run    echo 'cleanup executed'
@@ -163,7 +89,7 @@ Cleanup
 
 DeleteAll
     Log    Deleting all SRL Config
-    FOR  ${node}    IN    @{SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
         Delete Config from node
         ...    ${node}
         ...    --skip-verify -e PROTO
@@ -176,4 +102,123 @@ DeleteAll
         ...    ${SRL_USERNAME}
         ...    ${SRL_PASSWORD}
         ...    "/interface[name=ethernet-1/*]"
+    END
+
+Verify Intent Config On Node
+    [Arguments]    ${intent}    ${node}    ${expected_file}
+    @{expectedoutput} =    Load JSON from file    ${expected_file}
+    ${compare} =    Get Config from node and Verify Intent
+    ...    ${node}
+    ...    ${options}
+    ...    ${SRL_USERNAME}
+    ...    ${SRL_PASSWORD}
+    ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
+    ...    ${expectedoutput}
+    Should Be True    ${compare}
+
+Verify Intent Config Deleted On Node
+    [Arguments]    ${intent}    ${node}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SRL_USERNAME}
+    ...    ${SRL_PASSWORD}
+    ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
+    Should Be Empty    ${output}
+
+Create And Verify Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    ${EMPTY}    ${CURDIR}/input/srl    -srl
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Verify Intent Config On Node    ${intent}    ${node}    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+    END
+
+Delete And Verify Intent
+    [Arguments]    ${intent}
+    Delete Intent From K8s    ${intent}    -srl
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}
+    END
+
+Verify Orphan Deletion Policy For Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    ${EMPTY}    ${CURDIR}/input/srl    -srl
+    kubectl patch    config    ${intent}-srl    '{"spec": {"lifecycle": {"deletionPolicy": "orphan"}}}'
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Config Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    ${intent}-srl
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Verify Intent Config On Node    ${intent}    ${node}    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+    END
+    Delete Intent From K8s    ${intent}    -srl
+    Sleep    ${orphan_reconcile_grace}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node
+        ...    ${intent}
+        ...    ${node}
+        ...    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+    END
+    FOR    ${node}    IN    @{nodes}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/network-instance[name=${intents.${intent}}]"
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/interface[name=${intentsinterfaces.${intent}}]"
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}
+    END
+
+Verify Orphan Deletion Policy For ConfigSet
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    ${EMPTY}    ${CURDIR}/input/srl    -srl
+    kubectl patch    configset    ${intent}-srl    '{"spec": {"lifecycle": {"deletionPolicy": "orphan"}}}'
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    ConfigSet Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    ${intent}-srl
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Verify Intent Config On Node    ${intent}    ${node}    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+    END
+    Delete Intent From K8s    ${intent}    -srl
+    Sleep    ${orphan_reconcile_grace}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node
+        ...    ${intent}
+        ...    ${node}
+        ...    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+    END
+    FOR    ${node}    IN    @{nodes}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/network-instance[name=${intents.${intent}}]"
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/interface[name=${intentsinterfaces.${intent}}]"
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}
     END

--- a/tests/02-crud/21-sros-update-replace.robot
+++ b/tests/02-crud/21-sros-update-replace.robot
@@ -9,6 +9,7 @@ Resource            ../Keywords/targets.robot
 Resource            ../Keywords/config.robot
 Resource            ../Keywords/yq.robot
 Resource            ../Keywords/gnmic.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
@@ -16,176 +17,49 @@ Suite Teardown      Run Keyword    Cleanup
 *** Variables ***
 # sr1 = netconf ; sr2 = gNMI get
 
-@{SDCIO_SROS_NODES}     sr1    sr2
+@{SDCIO_SROS_NODES}           sr1    sr2
 @{SDCIO_CONFIGSET_INTENTS}    intent1    intent2
-@{SDCIO_CONFIG_INTENTS}    intent3    intent4
-&{intents}        intent1=vprn123    intent2=vprn234    intent3=vprn789    intent4=vprn987
-&{replaceintents}        intent1=vprn1123    intent2=vprn1234    intent3=vprn1789    intent4=vprn1987
-${options}    --insecure -e JSON
-${filter}    "configure/service/vprn"
+@{SDCIO_CONFIG_INTENTS}       intent3    intent4
+&{intents}                    intent1=vprn123    intent2=vprn234    intent3=vprn789    intent4=vprn987
+&{replaceintents}             intent1=vprn1123    intent2=vprn1234    intent3=vprn1789    intent4=vprn1987
+${options}                    --insecure -e JSON
+${filter}                     "configure/service/vprn"
+${eventual_timeout}           2min
+${retry}                      2s
+${INTENT_TARGET_CACHE}        ${None}    # populated by Initialize Intent Target Cache in Setup
 
 *** Test Cases ***
-Update and Verify Config(Set)
-    [Documentation]    Verify Config(Set) resources are updated and verify on SROS nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Update And Verify intent1
+    [Tags]    update
+    Update And Verify Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # Update the Config(Set) Intent
-        Log    Update Config(Set) for intent ${intent}
-        ${rc}    ${output}=    kubectl apply    ${CURDIR}/input/sros/${intent}-sros-update.yaml
+Update And Verify intent2
+    [Tags]    update
+    Update And Verify Intent    intent2
 
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            # Verify the (updated) ConfigSet is in a ready state in k8s
-            Log    Verify Updated ConfigSet ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    ConfigSet Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-sros
-        ELSE    
-            # Verify the (updated) Config is transitioning to a ready state in k8s
-            Log    Verify Updated Config ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Config Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-sros
-        END
-        # Updating/Replacing the config intent will not cause the READY state to be changed, waiting a few seconds to ensure the intent is applied.
-        Sleep    5s
-        # Verify the Config is replaced on the SROS nodes
-        Log   Verify Upgraded ConfigSet ${intent} on ${SDCIO_SROS_NODES}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Note, as the gnmic output is not properly JSON formatted, we need to save the gnmic output initially to a file, 
-            # to be able to compare it in consecutive runs.
-            # ONLY UNCOMMENT THE FOLLOWING LINES IF YOU NEED TO UPDATE THE EXPECTED OUTPUT
-            # START BLOCK
-            # ${gnmicoutput} =    Get Config from node
-            # ...    ${node}
-            # ...    ${options}
-            # ...    ${SROS_USERNAME}
-            # ...    ${SROS_PASSWORD}
-            # ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            # ...    ${filter}
-            # Save JSON to file    ${gnmicoutput}    ${CURDIR}/expectedoutput/sros/${intent}-sros-update.json
-            # END BLOCK
+Update And Verify intent3
+    [Tags]    update
+    Update And Verify Intent    intent3
 
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros-update.json
+Update And Verify intent4
+    [Tags]    update
+    Update And Verify Intent    intent4
 
-            ${compare} =    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-            
-            Should Be True      ${compare}
-        END
-    END
+Replace And Verify intent1
+    [Tags]    replace
+    Replace And Verify Intent    intent1
 
-Replace and Verify Config(Set)
-    [Documentation]    Verify Config(Set) resources are replaced and verify on SROS nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Replace And Verify intent2
+    [Tags]    replace
+    Replace And Verify Intent    intent2
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # Replace the Config(Set) Intent
-        Log    Replace Config(Set) for intent ${intent}
-        ${rc}    ${output}=    kubectl apply    ${CURDIR}/input/sros/${intent}-sros-replace.yaml
+Replace And Verify intent3
+    [Tags]    replace
+    Replace And Verify Intent    intent3
 
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            # Verify the (replaced) ConfigSet is in a ready state in k8s
-            Log    Verify Replaced ConfigSet ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    ConfigSet Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-sros
-        ELSE
-            # Verify the (replaced) Config is transitioning to a ready state in k8s
-            Log    Verify Replaced Config ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Config Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-sros
-        END
-        # Updating/Replacing the config intent will not cause the READY state to be changed, waiting a few seconds to ensure the intent is applied.
-        Sleep    5s
-        # Verify the Config is replaced on the SROS nodes
-        Log   Verify Replaced Config(Set) ${intent} on ${SDCIO_SROS_NODES}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Note, as the gnmic output is not properly JSON formatted, we need to save the gnmic output initially to a file, 
-            # to be able to compare it in consecutive runs.
-            # ONLY UNCOMMENT THE FOLLOWING LINES IF YOU NEED TO UPDATE THE EXPECTED OUTPUT
-            # START BLOCK
-            # ${gnmicoutput} =    Get Config from node
-            # ...    ${node}
-            # ...    ${options}
-            # ...    ${SROS_USERNAME}
-            # ...    ${SROS_PASSWORD}
-            # ...    "/configure/service/vprn[service-name=${replaceintents.${intent}}]"
-            # ...    ${filter}
-            # Save JSON to file    ${gnmicoutput}    ${CURDIR}/expectedoutput/sros/${intent}-sros-replace.json
-            # END BLOCK
-
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros-replace.json
-
-            ${compare} =    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${replaceintents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-
-            Should Be True      ${compare}
-        END
-        
-        # Verify the old Config is gone on the SROS nodes
-        Log   Verify Old Config(Set) ${intent} is gone on ${SDCIO_SROS_NODES}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${filter}
-
-            # [HT] Fix, remove None values from output list, before checking if it's empty
-            ${output} =   Evaluate    [i for i in ${output} if i]
-    	    Should Be Empty    ${output}
-        END
-    END
+Replace And Verify intent4
+    [Tags]    replace
+    Replace And Verify Intent    intent4
 
 *** Keywords ***
 Setup
@@ -213,6 +87,7 @@ Setup
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-sros
     END
+    Initialize Intent Target Cache    ${CURDIR}/input/sros    -sros
 
 Cleanup
     Run    echo 'cleanup executed'
@@ -237,7 +112,7 @@ Cleanup
 
 DeleteAll
     Log    Deleting all SROS Config
-    FOR  ${node}    IN    @{SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{SDCIO_SROS_NODES}
         Delete Config from node
         ...    ${node}
         ...    ${options}
@@ -245,3 +120,51 @@ DeleteAll
         ...    ${SROS_PASSWORD}
         ...    "/configure/service/vprn[service-name=*]"
     END
+
+Verify Intent Config On Node
+    [Arguments]    ${intent}    ${node}    ${vprn_name}    ${expected_file}
+    @{expectedoutput} =    Load JSON from file    ${expected_file}
+    ${compare} =    Get Config from node and Verify Intent
+    ...    ${node}
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    "/configure/service/vprn[service-name=${vprn_name}]"
+    ...    ${expectedoutput}
+    ...    ${filter}
+    Should Be True    ${compare}
+
+Verify Intent Config Deleted On Node
+    [Arguments]    ${intent}    ${node}    ${vprn_name}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    "/configure/service/vprn[service-name=${vprn_name}]"
+    ...    ${filter}
+    ${output} =    Evaluate    [i for i in ${output} if i]
+    Should Be Empty    ${output}
+
+Update And Verify Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    -update    ${CURDIR}/input/sros    -sros
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node    ${intent}    ${node}
+        ...    ${intents.${intent}}    ${CURDIR}/expectedoutput/sros/${intent}-sros-update.json
+    END
+
+Replace And Verify Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    -replace    ${CURDIR}/input/sros    -sros
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node    ${intent}    ${node}
+        ...    ${replaceintents.${intent}}    ${CURDIR}/expectedoutput/sros/${intent}-sros-replace.json
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}    ${intents.${intent}}
+    END
+

--- a/tests/02-crud/22-srl-update-replace.robot
+++ b/tests/02-crud/22-srl-update-replace.robot
@@ -9,174 +9,63 @@ Resource            ../Keywords/targets.robot
 Resource            ../Keywords/config.robot
 Resource            ../Keywords/yq.robot
 Resource            ../Keywords/gnmic.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
 
 *** Variables ***
-# sr1 = netconf ; sr2 = gNMI get
-
-@{SDCIO_SRL_NODES}     srl1    srl2    srl3
+@{SDCIO_SRL_NODES}            srl1    srl2    srl3
 @{SDCIO_CONFIGSET_INTENTS}    intent1    intent2
-@{SDCIO_CONFIG_INTENTS}    intent3    intent4    intent5
-&{intents}        intent1=vrf1    intent2=vrf2    intent3=vrf3    intent4=vrf4    intent5=vrf5
-&{replaceintents}        intent1=vrf11    intent2=vrf12    intent3=vrf13    intent4=vrf14    intent5=vrf15
-&{intentsinterfaces}        intent1=ethernet-1/1    intent2=ethernet-1/2    intent3=ethernet-1/3    intent4=ethernet-1/4    intent5=ethernet-1/5
-${options}    --skip-verify -e PROTO
+@{SDCIO_CONFIG_INTENTS}       intent3    intent4    intent5
+&{intents}                    intent1=vrf1    intent2=vrf2    intent3=vrf3    intent4=vrf4    intent5=vrf5
+&{replaceintents}             intent1=vrf11    intent2=vrf12    intent3=vrf13    intent4=vrf14    intent5=vrf15
+&{intentsinterfaces}          intent1=ethernet-1/1    intent2=ethernet-1/2    intent3=ethernet-1/3    intent4=ethernet-1/4    intent5=ethernet-1/5
+${options}                    --skip-verify -e PROTO
+${eventual_timeout}           2min
+${retry}                      2s
+${INTENT_TARGET_CACHE}        ${None}    # populated by Initialize Intent Target Cache in Setup
 
 *** Test Cases ***
-Update and Verify Config(Set)
-    [Documentation]    Verify Config(Set) resources are updated and verify on SRL nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Update And Verify intent1
+    [Tags]    update
+    Update And Verify Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # Update the Config(Set) Intent
-        Log    Update Config(Set) for intent ${intent}
-        ${rc}    ${output}=    kubectl apply    ${CURDIR}/input/srl/${intent}-srl-update.yaml
+Update And Verify intent2
+    [Tags]    update
+    Update And Verify Intent    intent2
 
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            # Verify the ConfigSet is in a ready state in k8s
-            Log    Verify Updated ConfigSet ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    ConfigSet Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-srl
-        ELSE
-            # Verify the Config is in a ready state in k8s
-            Log    Verify Updated Config ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Config Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-srl
-        END
-        # Updating/Replacing the config intent will not cause the READY state to be changed, waiting a few seconds to ensure the intent is applied.
-        Sleep    5s
-        # Verify the (updated) Config is applied on the SRL nodes
-        Log   Verify Updated Config(Set) ${intent} on ${SDCIO_SRL_NODES}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Note, as the gnmic output is not properly JSON formatted, we need to save the gnmic output initially to a file, 
-            # to be able to compare it in consecutive runs.
-            # ONLY UNCOMMENT THE FOLLOWING LINE IF YOU NEED TO UPDATE THE EXPECTED OUTPUT
-            # START BLOCK
-            # ${gnmicoutput} =    Get Config from node
-            # ...    ${node}
-            # ...    ${options}
-            # ...    ${SRL_USERNAME}
-            # ...    ${SRL_PASSWORD}
-            # ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            # Save JSON to file    ${gnmicoutput}    ${CURDIR}/expectedoutput/srl/${intent}-srl-update.json
-            # END BLOCK
+Update And Verify intent3
+    [Tags]    update
+    Update And Verify Intent    intent3
 
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl-update.json
+Update And Verify intent4
+    [Tags]    update
+    Update And Verify Intent    intent4
 
-            ${compare} =    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-            
-            Should Be True      ${compare}
-        END
-    END
+Update And Verify intent5
+    [Tags]    update
+    Update And Verify Intent    intent5
 
-Replace and Verify Config(Set)
-    [Documentation]    Verify Config(Set) resources are replaced and verify on SRL nodes
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Replace And Verify intent1
+    [Tags]    replace
+    Replace And Verify Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # Replace the Config(Set) Intent
-        Log    Replace Config(Set) for intent ${intent}
-        ${rc}    ${output}=    kubectl apply    ${CURDIR}/input/srl/${intent}-srl-replace.yaml
+Replace And Verify intent2
+    [Tags]    replace
+    Replace And Verify Intent    intent2
 
-        IF    $intent in $SDCIO_CONFIGSET_INTENTS
-            # Verify the ConfigSet is transitioning to a ready state in k8s
-            Log    Verify Replaced ConfigSet ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    ConfigSet Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-srl
-        ELSE
-            # Verify the Config is in a ready state in k8s
-            Log    Verify Replaced Config ${intent} is ready on k8s
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Config Check Ready
-            ...    ${SDCIO_RESOURCE_NAMESPACE}
-            ...    ${intent}-srl
-        END
-        # Updating/Replacing the config intent will not cause the READY state to be changed, waiting a few seconds to ensure the intent is applied.
-        Sleep    5s
-        # Verify the (replaced) Config is applied on the SRL nodes
-        Log   Verify Replaced Config(Set) ${intent} on ${SDCIO_SRL_NODES}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Note, as the gnmic output is not properly JSON formatted, we need to save the gnmic output initially to a file, 
-            # to be able to compare it in consecutive runs.
-            # ONLY UNCOMMENT THE FOLLOWING LINE IF YOU NEED TO UPDATE THE EXPECTED OUTPUT
-            # START BLOCK
-            # ${gnmicoutput} =    Get Config from node
-            # ...    ${node}
-            # ...    ${options}
-            # ...    ${SRL_USERNAME}
-            # ...    ${SRL_PASSWORD}
-            # ...    "/network-instance[name=${replaceintents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            # Save JSON to file    ${gnmicoutput}    ${CURDIR}/expectedoutput/srl/${intent}-srl-replace.json
-            # END BLOCK
+Replace And Verify intent3
+    [Tags]    replace
+    Replace And Verify Intent    intent3
 
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl-replace.json
+Replace And Verify intent4
+    [Tags]    replace
+    Replace And Verify Intent    intent4
 
-            ${compare} =    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${replaceintents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-            
-            Should Be True      ${compare}
-        END
-        Log  Verify Old Config(Set) ${intent} is removed from ${SDCIO_SRL_NODES}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]"
-
-    	    Should Be Empty    ${output}
-        END
-    END
+Replace And Verify intent5
+    [Tags]    replace
+    Replace And Verify Intent    intent5
 
 *** Keywords ***
 Setup
@@ -202,6 +91,7 @@ Setup
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-srl
     END
+    Initialize Intent Target Cache    ${CURDIR}/input/srl    -srl
 
 Cleanup
     Run    echo 'cleanup executed'
@@ -225,7 +115,7 @@ Cleanup
 
 DeleteAll
     Log    Deleting all SRL Config
-    FOR  ${node}    IN    @{SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
         Delete Config from node
         ...    ${node}
         ...    --skip-verify -e PROTO
@@ -239,3 +129,48 @@ DeleteAll
         ...    ${SRL_PASSWORD}
         ...    "/interface[name=ethernet-1/*]"
     END
+
+Verify Intent Config On Node
+    [Arguments]    ${intent}    ${node}    ${vrf_name}    ${expected_file}
+    @{expectedoutput} =    Load JSON from file    ${expected_file}
+    ${compare} =    Get Config from node and Verify Intent
+    ...    ${node}
+    ...    ${options}
+    ...    ${SRL_USERNAME}
+    ...    ${SRL_PASSWORD}
+    ...    "/network-instance[name=${vrf_name}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
+    ...    ${expectedoutput}
+    Should Be True    ${compare}
+
+Verify Intent Config Deleted On Node
+    [Arguments]    ${intent}    ${node}    ${vrf_name}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SRL_USERNAME}
+    ...    ${SRL_PASSWORD}
+    ...    "/network-instance[name=${vrf_name}]"
+    Should Be Empty    ${output}
+
+Update And Verify Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    -update    ${CURDIR}/input/srl    -srl
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node    ${intent}    ${node}
+        ...    ${intents.${intent}}    ${CURDIR}/expectedoutput/srl/${intent}-srl-update.json
+    END
+
+Replace And Verify Intent
+    [Arguments]    ${intent}
+    Apply Intent On K8s    ${intent}    -replace    ${CURDIR}/input/srl    -srl
+    @{nodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{nodes}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config On Node    ${intent}    ${node}
+        ...    ${replaceintents.${intent}}    ${CURDIR}/expectedoutput/srl/${intent}-srl-replace.json
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Verify Intent Config Deleted On Node    ${intent}    ${node}    ${intents.${intent}}
+    END
+

--- a/tests/02-crud/sros/customer.json
+++ b/tests/02-crud/sros/customer.json
@@ -1,0 +1,21 @@
+[
+    {
+      "path": "/",
+      "value": {
+        "configure": {
+          "service": {
+            "customer": [
+              {
+                "customer-name": "1",
+                "customer-id": 1
+              },
+              {
+                "customer-name": "2",
+                "customer-id": 2
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]

--- a/tests/02-crud/sros/intent1-sros.json
+++ b/tests/02-crud/sros/intent1-sros.json
@@ -1,0 +1,17 @@
+[
+    {
+      "path": "/",
+      "value": {
+        "configure": {
+          "service": {
+            "vprn": {
+              "service-name": "vprn123",
+              "customer": "1",
+              "service-id": "101",
+              "admin-state": "enable"
+            }
+          }
+        }
+      }
+    }
+  ]

--- a/tests/02-crud/sros/intent3-sros.json
+++ b/tests/02-crud/sros/intent3-sros.json
@@ -1,0 +1,17 @@
+[
+  {
+    "path": "/",
+    "value": {
+      "configure": {
+        "service": {
+          "vprn": {
+            "service-name": "vprn789",
+            "customer": "1",
+            "service-id": "103",
+            "admin-state": "enable"
+          }
+        }
+      }
+    }
+  }
+]

--- a/tests/03-deviations/11-sros-revertive.robot
+++ b/tests/03-deviations/11-sros-revertive.robot
@@ -9,6 +9,7 @@ Resource            ../Keywords/targets.robot
 Resource            ../Keywords/config.robot
 Resource            ../Keywords/gnmic.robot
 Resource            ../Keywords/yq.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
@@ -21,192 +22,57 @@ Suite Teardown      Run Keyword    Cleanup
 @{SDCIO_CONFIG_INTENTS}    intent3    intent4
 &{intents}        intent1=vprn123    intent2=vprn234    intent3=vprn789    intent4=vprn987
 ${retry}    2s
+${eventual_timeout}    2min
 ${options}    --insecure -e JSON
 ${filter}    "configure/service/vprn"
+${VERIFY_IMMEDIATE_DEVICE_DELETE}    ${FALSE}
+${INTENT_TARGET_CACHE}    ${None}
 
 *** Test Cases ***
-Delete SROS device config and Verify Revertive Deviations
-    [Documentation]    Delete device config and Verify Revertive Deviations on ConfigSets
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Delete SROS device config and Verify Revertive Deviations - intent1
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent1
+    Run Delete And Verify Revertive For Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Delete device config for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Delete ConfigSet ${intent} on ${node}
-            # Delete the config from the device using gNMIc
-            Delete Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            # Verify the config is deleted from the device using gNMIc
-            Log    Verify Deletion of ConfigSet ${intent} on ${node}
-            ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${filter}
+Delete SROS device config and Verify Revertive Deviations - intent2
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent2
+    Run Delete And Verify Revertive For Intent    intent2
 
-            # [HT] Fix, remove None values from output list, before checking if it's empty
-            ${output} =   Evaluate    [i for i in ${output} if i]
-    	    Should Be Empty    ${output}
-        END
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Wait for Deviations to pick up and revert the config delete on ${node}
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
-            # Wait until the config is reverted back on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-    END
+Delete SROS device config and Verify Revertive Deviations - intent3
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent3
+    Run Delete And Verify Revertive For Intent    intent3
+
+Delete SROS device config and Verify Revertive Deviations - intent4
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent4
+    Run Delete And Verify Revertive For Intent    intent4
 
 Delete ALL SROS device config and Verify Revertive Deviations
     [Documentation]    Delete device config and Verify Revertive Deviations on Config(Set) -- multiple intents at once
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+    Delete All Device Config
+    Verify All Intents Are Reverted
 
-    FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Log    Deleting ALL Config(Set) intents on ${node}
-        # Delete the config from the device using gNMIc
-        Delete Config from node
-        ...    ${node}
-        ...    ${options}
-        ...    ${SROS_USERNAME}
-        ...    ${SROS_PASSWORD}
-        ...    "/configure/service/vprn[service-name=*]"
-        # Verify the config is deleted from the device using gNMIc
-        Log    Verify Deletion of Config(Set) intents on ${node}
-        ${output} =    Get Config from node
-        ...    ${node}
-        ...    ${options}
-        ...    ${SROS_USERNAME}
-        ...    ${SROS_PASSWORD}
-        ...    "/configure/service/vprn[service-name=*]"
-        ...    ${filter}
-        # [HT] Fix, remove None values from output list, before checking if it's empty
-        ${output} =   Evaluate    [i for i in ${output} if i]
-        Should Be Empty    ${output}
-    END
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Wait for Deviations to pick up and revert the config delete on ${node}
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
-            # Wait until the config is reverted back on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-    END
+Adjust SROS device config and Verify Revertive Deviations - intent1
+    [Documentation]    Adjust SROS config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent1
+    Run Adjust And Verify Revertive For Intent    intent1
 
-Adjust SROS device config and Verify Revertive Deviations
-    [Documentation]    Adjust (some) SROS device config and Verify Revertive Deviations
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Adjust device config for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Creating Deviations on ${node} for intent ${intent}
-            # Adjust the config on the device using gNMIc
-            Set Config on node via file
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]/"
-            ...    ${CURDIR}/input/sros/deviations-${intent}.json
-            # Verify the config is adjusted on the device using gNMIc
-            Log    Verify Deviation Creation on ${node} of intent ${intent}
-        END
-        # The deviation has been created, now verify the system will rollback the deviation and the original intent is back in place
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-    END
+Adjust SROS device config and Verify Revertive Deviations - intent2
+    [Documentation]    Adjust SROS config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent2
+    Run Adjust And Verify Revertive For Intent    intent2
+
+Adjust SROS device config and Verify Revertive Deviations - intent3
+    [Documentation]    Adjust SROS config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent3
+    Run Adjust And Verify Revertive For Intent    intent3
+
+Adjust SROS device config and Verify Revertive Deviations - intent4
+    [Documentation]    Adjust SROS config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent4
+    Run Adjust And Verify Revertive For Intent    intent4
 
 *** Keywords ***
 Setup
@@ -215,11 +81,11 @@ Setup
         Wait Until Keyword Succeeds    5min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
-    Wait Until Keyword Succeeds    2min    ${retry}    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"
+    Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/sros/${intent}-sros.yaml
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    ConfigSet Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
@@ -228,11 +94,115 @@ Setup
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         kubectl apply    ${CURDIR}/input/sros/${intent}-sros.yaml
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Config Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-sros
+    END
+    Initialize Intent Target Cache    ${CURDIR}/input/sros    -sros
+
+Run Delete And Verify Revertive For Intent
+    [Arguments]    ${intent}
+    Delete Device Config For Intent    ${intent}
+    Verify Intent Is Reverted    ${intent}
+
+Run Adjust And Verify Revertive For Intent
+    [Arguments]    ${intent}
+    Adjust Device Config For Intent    ${intent}
+    Verify Intent Is Reverted    ${intent}
+
+Delete Device Config For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Log    Deleting config for intent ${intent} on ${node}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+        Run Keyword If    ${VERIFY_IMMEDIATE_DEVICE_DELETE}
+        ...    Verify Intent Config Is Deleted On Node
+        ...    ${intent}
+        ...    ${node}
+    END
+
+Verify Intent Config Is Deleted On Node
+    [Arguments]    ${intent}    ${node}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+    ...    ${filter}
+    ${output} =    Evaluate    [i for i in ${output} if i]
+    Should Be Empty    ${output}
+
+Adjust Device Config For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Log    Adjusting config for intent ${intent} on ${node}
+        Set Config on node via file
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]/"
+        ...    ${CURDIR}/input/sros/deviations-${intent}.json
+    END
+
+Verify Intent Is Reverted
+    [Arguments]    ${intent}
+    @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Get Config from node and Verify Intent
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+        ...    ${expectedoutput}
+        ...    ${filter}
+    END
+
+Delete All Device Config
+    FOR    ${node}    IN    @{SDCIO_SROS_NODES}
+        Log    Deleting all vprn config on ${node}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=*]"
+        Run Keyword If    ${VERIFY_IMMEDIATE_DEVICE_DELETE}
+        ...    Verify All Intent Config Is Deleted On Node
+        ...    ${node}
+    END
+
+Verify All Intent Config Is Deleted On Node
+    [Arguments]    ${node}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    "/configure/service/vprn[service-name=*]"
+    ...    ${filter}
+    ${output} =    Evaluate    [i for i in ${output} if i]
+    Should Be Empty    ${output}
+
+Verify All Intents Are Reverted
+    @{all_intents} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+    FOR    ${intent}    IN    @{all_intents}
+        Verify Intent Is Reverted    ${intent}
     END
 
 Cleanup
@@ -240,7 +210,7 @@ Cleanup
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-sros
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}-sros
@@ -248,7 +218,7 @@ Cleanup
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-sros
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}-sros

--- a/tests/03-deviations/12-srl-revertive.robot
+++ b/tests/03-deviations/12-srl-revertive.robot
@@ -9,6 +9,7 @@ Resource            ../Keywords/targets.robot
 Resource            ../Keywords/config.robot
 Resource            ../Keywords/gnmic.robot
 Resource            ../Keywords/yq.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
@@ -22,186 +23,68 @@ Suite Teardown      Run Keyword    Cleanup
 &{intents}        intent1=vrf1    intent2=vrf2    intent3=vrf3    intent4=vrf4    intent5=vrf5
 &{intentsinterfaces}        intent1=ethernet-1/1    intent2=ethernet-1/2    intent3=ethernet-1/3    intent4=ethernet-1/4    intent5=ethernet-1/5
 ${retry}    2s
+${eventual_timeout}    2min
 ${options}    --skip-verify -e PROTO
 ${optionsSet}    --skip-verify -e JSON_IETF
+${VERIFY_IMMEDIATE_DEVICE_DELETE}    ${FALSE}
+${INTENT_TARGET_CACHE}    ${None}
 
 
 *** Test Cases ***
-Delete SRL device config and Verify Revertive Deviations
-    [Documentation]    Delete device config and Verify Revertive Deviations on ConfigSets
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Delete SRL device config and Verify Revertive Deviations - intent1
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent1
+    Run Delete And Verify Revertive For Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Delete device config for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Delete ConfigSet ${intent} on ${node}
-            # Delete the config from the device using gNMIc
-            Delete Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]"
-            # Verify the config is deleted from the device using gNMIc
-            Log    Verify Deletion of ConfigSet ${intent} on ${node}
-            ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]"
+Delete SRL device config and Verify Revertive Deviations - intent2
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent2
+    Run Delete And Verify Revertive For Intent    intent2
 
-    	    Should Be Empty    ${output}
-        END
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Wait for Deviations to pick up and revert the config delete on ${node}
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
-            # Wait until the config is reverted back on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-    END
+Delete SRL device config and Verify Revertive Deviations - intent3
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent3
+    Run Delete And Verify Revertive For Intent    intent3
+
+Delete SRL device config and Verify Revertive Deviations - intent4
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent4
+    Run Delete And Verify Revertive For Intent    intent4
+
+Delete SRL device config and Verify Revertive Deviations - intent5
+    [Documentation]    Delete device config and verify revertive behavior for one intent.
+    [Tags]    revertive    delete-config    verify    intent5
+    Run Delete And Verify Revertive For Intent    intent5
 
 Delete ALL SRL device config and Verify Revertive Deviations
     [Documentation]    Delete device config and Verify Revertive Deviations on Config(Set) -- multiple intents at once
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+    Delete All Device Config
+    Verify All Intents Are Reverted
 
-    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Log    Deleting ALL Config(Set) intents on ${node}
-        # Delete the config from the device using gNMIc
-        Delete Config from node
-        ...    ${node}
-        ...    ${options}
-        ...    ${SRL_USERNAME}
-        ...    ${SRL_PASSWORD}
-        ...    "/network-instance[name=vrf*]"
-        # Verify the config is deleted from the device using gNMIc
-        Log    Verify Deletion of Config(Set) intents on ${node}
-        ${output} =    Get Config from node
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=vrf*]"
+Adjust SRL device config and Verify Revertive Deviations - intent1
+    [Documentation]    Adjust SRL config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent1
+    Run Adjust And Verify Revertive For Intent    intent1
 
-        Should Be Empty    ${output}
-    END
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Wait for Deviations to pick up and revert the config delete on ${node}
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
-            # Wait until the config is reverted back on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-    END
+Adjust SRL device config and Verify Revertive Deviations - intent2
+    [Documentation]    Adjust SRL config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent2
+    Run Adjust And Verify Revertive For Intent    intent2
 
-Adjust SRL device config and Verify Revertive Deviations
-    [Documentation]    Adjust (some) SRL device config and Verify Revertive Deviations
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Adjust device config for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Creating Deviations on ${node} for intent ${intent}
-            # Adjust the config on the device using gNMIc
-            Set Config on node via file
-            ...    ${node}
-            ...    ${optionsSet}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/"
-            ...    ${CURDIR}/input/srl/deviations-${intent}.json
-            #...    "/network-instance[name=${intents.${intent}}]"            
-            # Verify the config is adjusted on the device using gNMIc
-            Log    Verify Deviation Creation on ${node} of intent ${intent}
-        END
-        # The deviation has been created, now verify the system will rollback the deviation and the original intent is back in place
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-    END
+Adjust SRL device config and Verify Revertive Deviations - intent3
+    [Documentation]    Adjust SRL config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent3
+    Run Adjust And Verify Revertive For Intent    intent3
+
+Adjust SRL device config and Verify Revertive Deviations - intent4
+    [Documentation]    Adjust SRL config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent4
+    Run Adjust And Verify Revertive For Intent    intent4
+
+Adjust SRL device config and Verify Revertive Deviations - intent5
+    [Documentation]    Adjust SRL config and verify revertive behavior for one intent.
+    [Tags]    revertive    adjust-config    verify    intent5
+    Run Adjust And Verify Revertive For Intent    intent5
 
 *** Keywords ***
 Setup
@@ -212,7 +95,7 @@ Setup
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    ConfigSet Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
@@ -221,11 +104,110 @@ Setup
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Config Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-srl
+    END
+    Initialize Intent Target Cache    ${CURDIR}/input/srl    -srl
+
+Run Delete And Verify Revertive For Intent
+    [Arguments]    ${intent}
+    Delete Device Config For Intent    ${intent}
+    Verify Intent Is Reverted    ${intent}
+
+Run Adjust And Verify Revertive For Intent
+    [Arguments]    ${intent}
+    Adjust Device Config For Intent    ${intent}
+    Verify Intent Is Reverted    ${intent}
+
+Delete Device Config For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Log    Deleting config for intent ${intent} on ${node}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/network-instance[name=${intents.${intent}}]"
+        Run Keyword If    ${VERIFY_IMMEDIATE_DEVICE_DELETE}
+        ...    Verify Intent Config Is Deleted On Node
+        ...    ${intent}
+        ...    ${node}
+    END
+
+Verify Intent Config Is Deleted On Node
+    [Arguments]    ${intent}    ${node}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SRL_USERNAME}
+    ...    ${SRL_PASSWORD}
+    ...    "/network-instance[name=${intents.${intent}}]"
+    Should Be Empty    ${output}
+
+Adjust Device Config For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Log    Adjusting config for intent ${intent} on ${node}
+        Set Config on node via file
+        ...    ${node}
+        ...    ${optionsSet}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/"
+        ...    ${CURDIR}/input/srl/deviations-${intent}.json
+    END
+
+Verify Intent Is Reverted
+    [Arguments]    ${intent}
+    @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Get Config from node and Verify Intent
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
+        ...    ${expectedoutput}
+    END
+
+Delete All Device Config
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+        Log    Deleting all vrf config on ${node}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/network-instance[name=vrf*]"
+        Run Keyword If    ${VERIFY_IMMEDIATE_DEVICE_DELETE}
+        ...    Verify All Intent Config Is Deleted On Node
+        ...    ${node}
+    END
+
+Verify All Intent Config Is Deleted On Node
+    [Arguments]    ${node}
+    ${output} =    Get Config from node
+    ...    ${node}
+    ...    ${options}
+    ...    ${SRL_USERNAME}
+    ...    ${SRL_PASSWORD}
+    ...    "/network-instance[name=vrf*]"
+    Should Be Empty    ${output}
+
+Verify All Intents Are Reverted
+    @{all_intents} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+    FOR    ${intent}    IN    @{all_intents}
+        Verify Intent Is Reverted    ${intent}
     END
 
 Cleanup
@@ -233,7 +215,7 @@ Cleanup
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-srl
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}-srl
@@ -241,7 +223,7 @@ Cleanup
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-srl
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}-srl

--- a/tests/03-deviations/13-srl-onchange-encodings.robot
+++ b/tests/03-deviations/13-srl-onchange-encodings.robot
@@ -1,0 +1,165 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Process
+Library             Collections
+Resource            ../variables.robot
+Resource            ../Keywords/k8s/kubectl.robot
+Resource            ../Keywords/targets.robot
+Resource            ../Keywords/config.robot
+Resource            ../Keywords/gnmic.robot
+Resource            ../Keywords/deviation.robot
+Resource            ../Keywords/discovery.robot
+
+Suite Setup         Setup
+Suite Teardown      Run Keyword    Cleanup
+
+*** Variables ***
+@{SDCIO_SRL_NODES}          srl1       srl3    srl2 
+${retry}                    10s
+${eventual_timeout}         4min
+${discovery_timeout}        10min
+${options}                  --skip-verify -e PROTO
+${optionsSet}               --skip-verify -e JSON_IETF
+@{SRL_PROFILE_FILES}
+...                         ${CURDIR}/../01-crs/connection-profiles/conn_profile_srl_gnmi_proto.yaml
+...                         ${CURDIR}/../01-crs/connection-profiles/conn_profile_srl_gnmi_jsonietf.yaml
+...                         ${CURDIR}/../01-crs/sync-profiles/sync_profile_srl_gnmi_get.yaml
+...                         ${CURDIR}/../01-crs/sync-profiles/sync_profile_srl_gnmi_onchange.yaml
+...                         ${CURDIR}/../01-crs/sync-profiles/sync_profile_srl_gnmi_onchange_jsonietf.yaml
+@{SRL_ONCHANGE_DISCOVERY_RULE_FILES}
+...                         ${CURDIR}/../01-crs/discovery-rule/discovery_srl_gnmi_srl1_proto_onchange.yaml
+...                         ${CURDIR}/../01-crs/discovery-rule/discovery_srl_gnmi_srl2_jsonietf_onchange.yaml
+...                         ${CURDIR}/../01-crs/discovery-rule/discovery_srl_gnmi_srl3_jsonietf_onchange.yaml
+@{SRL_ONCHANGE_DISCOVERY_RULE_NAMES}
+...                         dr-srl-gnmi-srl1-proto-onchange
+...                         dr-srl-gnmi-srl2-jsonietf-onchange
+...                         dr-srl-gnmi-srl3-jsonietf-onchange
+${SRL_DEFAULT_DISCOVERY_RULE_FILE}    ${CURDIR}/../01-crs/discovery-rule/discovery_srl_gnmi_prefix.yaml
+
+*** Test Cases ***
+Verify SRL onChange discovery uses mixed encodings
+    Assert SRL OnChange Discovery State
+
+Detect SRL deviations under onChange across mixed encodings
+    Apply SRL Intent1 ConfigSet
+    Create SRL Intent1 Deviations
+    Verify SRL Intent1 Deviations
+
+*** Keywords ***
+Setup
+    Run    echo 'setup executed'
+    FOR    ${profile_file}    IN    @{SRL_PROFILE_FILES}
+        kubectl apply    ${profile_file}
+    END
+    Delete Discovery Rules If Present    dr-srl-gnmi-prefix
+    Delete Discovery Rules If Present    @{SRL_ONCHANGE_DISCOVERY_RULE_NAMES}
+    Apply Discovery Rules    @{SRL_ONCHANGE_DISCOVERY_RULE_FILES}
+    Assert SRL OnChange Discovery State
+
+Cleanup
+    Run    echo 'cleanup executed'
+    Cleanup SRL Intent And Deviations
+    Run Keyword If Any Tests Failed    DeleteAll
+    Delete Discovery Rules If Present    @{SRL_ONCHANGE_DISCOVERY_RULE_NAMES}
+    Apply Discovery Rules    ${SRL_DEFAULT_DISCOVERY_RULE_FILE}
+    Assert SRL Default Discovery State
+
+Assert SRL OnChange Discovery State
+    Wait Until Keyword Succeeds
+    ...    ${discovery_timeout}
+    ...    ${retry}
+    ...    Target Check Ready With Profiles
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    srl1
+    ...    test-srl-gnmi-proto
+    ...    test-srl-gnmi-onchange
+    Wait Until Keyword Succeeds
+    ...    ${discovery_timeout}
+    ...    ${retry}
+    ...    Target Check Ready With Profiles
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    srl2
+    ...    test-srl-gnmi-jsonietf
+    ...    test-srl-gnmi-onchange-jsonietf
+    Wait Until Keyword Succeeds
+    ...    ${discovery_timeout}
+    ...    ${retry}
+    ...    Target Check Ready With Profiles
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    srl3
+    ...    test-srl-gnmi-jsonietf
+    ...    test-srl-gnmi-onchange-jsonietf
+
+Assert SRL Default Discovery State
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+        Wait Until Keyword Succeeds
+        ...    ${discovery_timeout}
+        ...    ${retry}
+        ...    Target Check Ready With Profiles
+        ...    ${SDCIO_RESOURCE_NAMESPACE}
+        ...    ${node}
+        ...    test-srl-gnmi-proto
+        ...    test-srl-gnmi-get
+    END
+
+Apply SRL Intent1 ConfigSet
+    kubectl apply    ${CURDIR}/input/srl/intent1-srl.yaml
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    ConfigSet Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    intent1-srl
+
+Create SRL Intent1 Deviations
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+        Set Config on node via file
+        ...    ${node}
+        ...    ${optionsSet}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    /
+        ...    ${CURDIR}/input/srl/deviations-intent1.json
+    END
+
+Verify SRL Intent1 Deviations
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Verify Deviation on k8s
+        ...    intent1-srl-${node}
+        ...    6
+    END
+
+Cleanup SRL Intent And Deviations
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+        Run Keyword And Ignore Error    Delete Deviation CR    intent1-srl-${node}
+    END
+    ${status}    ${message} =    Run Keyword And Ignore Error
+    ...    Delete ConfigSet
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    intent1-srl
+    Run Keyword If    '${status}' == 'PASS'
+    ...    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Run Keyword And Expect Error
+    ...    *
+    ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev intent1-srl
+
+DeleteAll
+    FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    /network-instance[name=vrf*]
+        Delete Config from node
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    /interface[name=ethernet-1/*]
+    END

--- a/tests/03-deviations/13-srl-onchange-encodings.robot
+++ b/tests/03-deviations/13-srl-onchange-encodings.robot
@@ -104,6 +104,7 @@ Assert SRL Default Discovery State
 
 Apply SRL Intent1 ConfigSet
     kubectl apply    ${CURDIR}/input/srl/intent1-srl.yaml
+    kubectl patch    configset    intent1-srl    '{"spec": {"revertive": false}}'
     Wait Until Keyword Succeeds
     ...    ${eventual_timeout}
     ...    ${retry}
@@ -134,7 +135,7 @@ Verify SRL Intent1 Deviations
 
 Cleanup SRL Intent And Deviations
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Run Keyword And Ignore Error    Delete Deviation CR    intent1-srl-${node}
+        Run Keyword And Ignore Error    Delete Deviation    intent1-srl-${node}
     END
     ${status}    ${message} =    Run Keyword And Ignore Error
     ...    Delete ConfigSet

--- a/tests/03-deviations/14-sros-onchange-sync.robot
+++ b/tests/03-deviations/14-sros-onchange-sync.robot
@@ -10,7 +10,7 @@ Resource            ../Keywords/deviation.robot
 Resource            ../Keywords/discovery.robot
 
 Suite Setup         Setup
-# Suite Teardown      Run Keyword    Cleanup
+Suite Teardown      Run Keyword    Cleanup
 
 *** Variables ***
 ${retry}                    10s
@@ -88,6 +88,7 @@ Apply SROS Customer Context
 
 Apply SROS Intent4 Config
     kubectl apply    ${CURDIR}/input/sros/intent4-sros.yaml
+    kubectl patch    config    intent4-sros    '{"spec": {"revertive": false}}'
     Wait Until Keyword Succeeds
     ...    ${eventual_timeout}
     ...    ${retry}
@@ -132,7 +133,7 @@ Verify SROS Intent4 Deviation
     ...    3
 
 Cleanup SROS Intent And Deviations
-    Run Keyword And Ignore Error    Delete Deviation CR    intent4-sros
+    Run Keyword And Ignore Error    Delete Deviation    intent4-sros
     ${status}    ${message} =    Run Keyword And Ignore Error
     ...    Delete Config
     ...    ${SDCIO_RESOURCE_NAMESPACE}

--- a/tests/03-deviations/14-sros-onchange-sync.robot
+++ b/tests/03-deviations/14-sros-onchange-sync.robot
@@ -1,0 +1,155 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Process
+Resource            ../variables.robot
+Resource            ../Keywords/k8s/kubectl.robot
+Resource            ../Keywords/targets.robot
+Resource            ../Keywords/config.robot
+Resource            ../Keywords/gnmic.robot
+Resource            ../Keywords/deviation.robot
+Resource            ../Keywords/discovery.robot
+
+Suite Setup         Setup
+# Suite Teardown      Run Keyword    Cleanup
+
+*** Variables ***
+${retry}                    10s
+${eventual_timeout}         4min
+${discovery_timeout}        10min
+${options}                  --insecure -e JSON
+${filter}                   "configure/service/vprn"
+@{SROS_PROFILE_FILES}
+...                         ${CURDIR}/../01-crs/connection-profiles/conn_profile_sros_gnmi.yaml
+...                         ${CURDIR}/../01-crs/sync-profiles/sync_profile_sros_gnmi.yaml
+...                         ${CURDIR}/../01-crs/sync-profiles/sync_profile_sros_gnmi_onchange.yaml
+@{SROS_ONCHANGE_DISCOVERY_RULE_FILES}
+...                         ${CURDIR}/../01-crs/discovery-rule/discovery_sros_gnmi_sr2_onchange.yaml
+@{SROS_ONCHANGE_DISCOVERY_RULE_NAMES}
+...                         dr-sros-gnmi-sr2-onchange
+${SROS_DEFAULT_DISCOVERY_RULE_FILE}    ${CURDIR}/../01-crs/discovery-rule/discovery_sros_gnmi_prefix.yaml
+
+*** Test Cases ***
+Verify SROS gNMI onChange discovery becomes active
+    Assert SROS OnChange Discovery State
+
+Detect SROS deviations under gNMI onChange
+    Apply SROS Customer Context
+    Apply SROS Intent4 Config
+    Create SROS Intent4 Deviation
+    Verify SROS Intent4 Deviation
+
+*** Keywords ***
+Setup
+    Run    echo 'setup executed'
+    FOR    ${profile_file}    IN    @{SROS_PROFILE_FILES}
+        kubectl apply    ${profile_file}
+    END
+    Delete Discovery Rules If Present    dr-sros-gnmi-sr2
+    Delete Discovery Rules If Present    @{SROS_ONCHANGE_DISCOVERY_RULE_NAMES}
+    Apply Discovery Rules    @{SROS_ONCHANGE_DISCOVERY_RULE_FILES}
+    Assert SROS OnChange Discovery State
+
+Cleanup
+    Run    echo 'cleanup executed'
+    Cleanup SROS Intent And Deviations
+    Run Keyword If Any Tests Failed    DeleteAll
+    Delete Discovery Rules If Present    @{SROS_ONCHANGE_DISCOVERY_RULE_NAMES}
+    Apply Discovery Rules    ${SROS_DEFAULT_DISCOVERY_RULE_FILE}
+    Assert SROS Default Discovery State
+
+Assert SROS OnChange Discovery State
+    Wait Until Keyword Succeeds
+    ...    ${discovery_timeout}
+    ...    ${retry}
+    ...    Target Check Ready With Profiles
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    sr2
+    ...    test-sros-gnmi
+    ...    test-sros-gnmi-onchange-json
+
+Assert SROS Default Discovery State
+    Wait Until Keyword Succeeds
+    ...    ${discovery_timeout}
+    ...    ${retry}
+    ...    Target Check Ready With Profiles
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    sr2
+    ...    test-sros-gnmi
+    ...    test-sros-gnmi-getconfig
+
+Apply SROS Customer Context
+    kubectl apply    ${CURDIR}/input/sros/customer.yaml
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    ConfigSet Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    customer
+
+Apply SROS Intent4 Config
+    kubectl apply    ${CURDIR}/input/sros/intent4-sros.yaml
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Config Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    intent4-sros
+
+Create SROS Intent4 Deviation
+    Set Config on node via file
+    ...    sr2
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    /configure/service/vprn[service-name=vprn987]/
+    ...    ${CURDIR}/input/sros/deviations-intent4.json
+    Verify SROS Intent4 Drift On Device
+
+Verify SROS Intent4 Drift On Device
+    ${admin_state} =    Get Config from node
+    ...    sr2
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    /configure/service/vprn[service-name=vprn987]/admin-state
+    ${admin_state_text} =    Convert To String    ${admin_state}
+    Should Contain    ${admin_state_text}    disable
+    ${customer} =    Get Config from node
+    ...    sr2
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    /configure/service/vprn[service-name=vprn987]/customer
+    ${customer_text} =    Convert To String    ${customer}
+    Should Contain    ${customer_text}    2
+
+Verify SROS Intent4 Deviation
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Verify Deviation on k8s
+    ...    intent4-sros
+    ...    3
+
+Cleanup SROS Intent And Deviations
+    Run Keyword And Ignore Error    Delete Deviation CR    intent4-sros
+    ${status}    ${message} =    Run Keyword And Ignore Error
+    ...    Delete Config
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    intent4-sros
+    Run Keyword If    '${status}' == 'PASS'
+    ...    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Run Keyword And Expect Error
+    ...    *
+    ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev intent4-sros
+    Run Keyword And Ignore Error    Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    customer
+
+DeleteAll
+    Delete Config from node
+    ...    sr2
+    ...    ${options}
+    ...    ${SROS_USERNAME}
+    ...    ${SROS_PASSWORD}
+    ...    /configure/service/vprn[service-name=*]

--- a/tests/03-deviations/21-sros-nonrevertive.robot
+++ b/tests/03-deviations/21-sros-nonrevertive.robot
@@ -10,6 +10,7 @@ Resource            ../Keywords/config.robot
 Resource            ../Keywords/gnmic.robot
 Resource            ../Keywords/yq.robot
 Resource            ../Keywords/deviation.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
@@ -23,317 +24,91 @@ Suite Teardown      Run Keyword    Cleanup
 &{intents}        intent1=vprn123    intent2=vprn234    intent3=vprn789    intent4=vprn987
 ${options}    --insecure -e JSON
 ${filter}    "configure/service/vprn"
+${retry}    2s
+${eventual_timeout}    65s
+${VERIFY_DEVICE_CONFIG_ON_FULL_ACCEPT}    ${FALSE}
+${INTENT_TARGET_CACHE}    ${None}
 
 *** Test Cases ***
-Create Deviations and Verify non-revertive behavior
-    [Documentation]    Create device deviations and Verify Non-Revertive Deviations on Config(Sets)
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create Deviations and Verify non-revertive behavior - intent1
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent1
+    Run Non-Revertive Scenario For Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Creating Deviations for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Creating Deviations on ${node} for intent ${intent}
-            # Create a deviation for the intent by applying config directly on the device
-            # Adjust the config on the device using gNMIc
-            Set Config on node via file
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]/"
-            ...    ${CURDIR}/input/sros/deviations-${intent}.json
-        END
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        # The deviation has been created, now verify the system will not rollback the deviation.
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Confirm in k8s that the config-server picks up the correct count of # deviations.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros-${node}
-                ...    3
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros
-                ...    3
-            END
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros-nonrevertive.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-    END
-    Sleep    10s
+Create Deviations and Verify non-revertive behavior - intent2
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent2
+    Run Non-Revertive Scenario For Intent    intent2
 
-Reject Deviations and Verify revertive behavior
-    [Documentation]    Reject Deviations and Verify Revertive Deviations on Config(Sets)
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create Deviations and Verify non-revertive behavior - intent3
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent3
+    Run Non-Revertive Scenario For Intent    intent3
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Rejecting Deviations for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Run Keyword
-                ...    Delete Deviation CR
-                ...    ${intent}-sros-${node}
-            ELSE
-                Run Keyword
-                ...    Delete Deviation CR
-                ...    ${intent}-sros
-            END
-        END
-        # Wait some time to allow the system to process the rejection
-        Sleep    5s
-        # The deviation has been rejected, now verify the system will rollback the deviation.
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Confirm in k8s that the config-server clears the deviations.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros-${node}
-                ...    0
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros
-                ...    0
-            END
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-    END
-    Sleep    10s
+Create Deviations and Verify non-revertive behavior - intent4
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent4
+    Run Non-Revertive Scenario For Intent    intent4
 
-Create Deviations, Partially accept and Verify, Fully accept and Verify
-    [Documentation]    Create Deviations and Partially accept them on Config(Sets), then fully accept them and Verify
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Reject Deviations and Verify revertive behavior - intent1
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent1
+    Run Revertive Scenario For Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # CREATE
-        Log    Creating Deviations for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Creating Deviations on ${node} for intent ${intent}
-            # Create a deviation for the intent by applying config directly on the device
-            # Adjust the config on the device using gNMIc
-            Set Config on node via file
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]/"
-            ...    ${CURDIR}/input/sros/deviations-${intent}.json
-        END
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros-${node}
-                ...    3
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros
-                ...    3
-            END
-        END
-        # PARTIALLY ACCEPT
-        # Deviations are created, now partially accept them for the intent.
-        kubectl apply    ${CURDIR}/input/sros/${intent}-sros-nonrevertive-partial.yaml
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros-${node}
-                ...    2
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros
-                ...    2
-            END
-            # check if config matches here
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros-nonrevertive.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-        # FULLY ACCEPT
-        # Deviations are created, now partially accept them for the intent.
-        kubectl apply    ${CURDIR}/input/sros/${intent}-sros-nonrevertive-full.yaml
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/sros/${intent}-sros.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SROS nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros-${node}
-                ...    0
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    10s
-                ...    Verify Deviation on k8s
-                ...    ${intent}-sros
-                ...    0
-            END
-            # check if config matches here
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/sros/${intent}-sros-nonrevertive.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    10s
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SROS_USERNAME}
-            ...    ${SROS_PASSWORD}
-            ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
-            ...    ${expectedoutput}
-            ...    ${filter}
-        END
-    END
+Reject Deviations and Verify revertive behavior - intent2
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent2
+    Run Revertive Scenario For Intent    intent2
+
+Reject Deviations and Verify revertive behavior - intent3
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent3
+    Run Revertive Scenario For Intent    intent3
+
+Reject Deviations and Verify revertive behavior - intent4
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent4
+    Run Revertive Scenario For Intent    intent4
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent1
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent1
+    Run Partial And Full Accept Scenario For Intent    intent1
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent2
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent2
+    Run Partial And Full Accept Scenario For Intent    intent2
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent3
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent3
+    Run Partial And Full Accept Scenario For Intent    intent3
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent4
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent4
+    Run Partial And Full Accept Scenario For Intent    intent4
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent1
+    [Documentation]    Create deviations, partially revert by admin-state filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent1
+    Run Partial Revert Scenario For Intent    intent1
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent2
+    [Documentation]    Create deviations, partially revert by admin-state filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent2
+    Run Partial Revert Scenario For Intent    intent2
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent3
+    [Documentation]    Create deviations, partially revert by admin-state filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent3
+    Run Partial Revert Scenario For Intent    intent3
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent4
+    [Documentation]    Create deviations, partially revert by admin-state filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent4
+    Run Partial Revert Scenario For Intent    intent4
 
 *** Keywords ***
 Setup
@@ -342,13 +117,18 @@ Setup
         Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
-    Wait Until Keyword Succeeds    2min    10s    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    ConfigSet Check Ready
+    ...    ${SDCIO_RESOURCE_NAMESPACE}
+    ...    customer
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/sros/${intent}-sros.yaml
         kubectl patch    configset    ${intent}-sros    '{"spec": {"revertive": false}}'
         Wait Until Keyword Succeeds
-        ...    2min
-        ...    10s
+        ...    ${eventual_timeout}
+        ...    ${retry}
         ...    ConfigSet Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-sros
@@ -357,37 +137,38 @@ Setup
         kubectl apply    ${CURDIR}/input/sros/${intent}-sros.yaml
         kubectl patch    config    ${intent}-sros    '{"spec": {"revertive": false}}'
         Wait Until Keyword Succeeds
-        ...    2min
-        ...    10s
+        ...    ${eventual_timeout}
+        ...    ${retry}
         ...    Config Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-sros
     END
+    Initialize Intent Target Cache    ${CURDIR}/input/sros    -sros
 
 Cleanup
     Run    echo 'cleanup executed'
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-sros
         Wait Until Keyword Succeeds
-        ...    2min
-        ...    10s
+        ...    ${eventual_timeout}
+        ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}-sros
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-sros
         Wait Until Keyword Succeeds
-        ...    2min
-        ...    10s
+        ...    ${eventual_timeout}
+        ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}-sros
     END
     Run Keyword If Any Tests Failed     DeleteAll
-    Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    "customer"
+    Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    customer
 
 DeleteAll
     Log    Deleting all SROS Config
-    FOR  ${node}    IN    @{SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{SDCIO_SROS_NODES}
         Delete Config from node
         ...    ${node}
         ...    ${options}
@@ -395,3 +176,144 @@ DeleteAll
         ...    ${SROS_PASSWORD}
         ...    "/configure/service/vprn[service-name=*]"
     END
+
+Run Non-Revertive Scenario For Intent
+    [Arguments]    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    3
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/sros/${intent}-sros-nonrevertive.json
+
+Run Revertive Scenario For Intent
+    [Arguments]    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    3
+    Reject Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    0
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/sros/${intent}-sros.json
+
+Run Partial And Full Accept Scenario For Intent
+    [Arguments]    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    3
+    kubectl apply    ${CURDIR}/input/sros/${intent}-sros-nonrevertive-partial.yaml
+    Verify Deviation Count For Intent    ${intent}    2
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/sros/${intent}-sros-nonrevertive.json
+    kubectl apply    ${CURDIR}/input/sros/${intent}-sros-nonrevertive-full.yaml
+    Verify Deviation Count For Intent    ${intent}    0
+    Run Keyword If    ${VERIFY_DEVICE_CONFIG_ON_FULL_ACCEPT}
+    ...    Verify Device Config For Intent
+    ...    ${intent}
+    ...    ${CURDIR}/expectedoutput/sros/${intent}-sros-nonrevertive.json
+
+Run Partial Revert Scenario For Intent
+    [Arguments]    ${intent}
+    Reset Intent Baseline For Intent    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    3
+    Partial Revert Deviations For Intent by Admin State    ${intent}
+
+Reset Intent Baseline For Intent
+    [Arguments]    ${intent}
+    kubectl apply    ${CURDIR}/input/sros/${intent}-sros.yaml
+    ${is_configset} =    Run Keyword And Return Status
+    ...    List Should Contain Value
+    ...    ${SDCIO_CONFIGSET_INTENTS}
+    ...    ${intent}
+    IF    ${is_configset}
+        kubectl patch    configset    ${intent}-sros    '{"spec": {"revertive": false}}'
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    ConfigSet Check Ready
+        ...    ${SDCIO_RESOURCE_NAMESPACE}
+        ...    ${intent}-sros
+    ELSE
+        kubectl patch    config    ${intent}-sros    '{"spec": {"revertive": false}}'
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Config Check Ready
+        ...    ${SDCIO_RESOURCE_NAMESPACE}
+        ...    ${intent}-sros
+    END
+
+Create Deviations For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Log    Creating deviations on ${node} for intent ${intent}
+        Set Config on node via file
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]/"
+        ...    ${CURDIR}/input/sros/deviations-${intent}.json
+    END
+
+Reject Deviations For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        ${deviation_name} =    Get Deviation Name    ${intent}    ${node}
+        Delete Deviation    ${deviation_name}
+    END
+
+Verify Deviation Count For Intent
+    [Arguments]    ${intent}    ${expected_count}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        ${deviation_name} =    Get Deviation Name    ${intent}    ${node}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Verify Deviation on k8s
+        ...    ${deviation_name}
+        ...    ${expected_count}
+    END
+
+Verify Device Config For Intent
+    [Arguments]    ${intent}    ${expected_output_file}
+    @{expectedoutput} =    Load JSON from file    ${expected_output_file}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Get Config from node and Verify Intent
+        ...    ${node}
+        ...    ${options}
+        ...    ${SROS_USERNAME}
+        ...    ${SROS_PASSWORD}
+        ...    "/configure/service/vprn[service-name=${intents.${intent}}]"
+        ...    ${expectedoutput}
+        ...    ${filter}
+    END
+
+Partial Revert Deviations For Intent by Admin State
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SROS_NODES}
+    ${targetnode} =    Get From List    ${targetnodes}    0
+    ${deviation_name} =    Get Deviation Name    ${intent}    ${targetnode}
+    ${filter_path} =    Set Variable    /configure/service/vprn[service-name=${intents.${intent}}]/admin-state
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    kubectl sdc deviation --deviation ${deviation_name} --filter-path ${filter_path} --revert
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Verify Deviation on k8s
+    ...    ${deviation_name}
+    ...    2
+
+Get Deviation Name
+    [Arguments]    ${intent}    ${node}
+    ${is_configset} =    Run Keyword And Return Status
+    ...    List Should Contain Value
+    ...    ${SDCIO_CONFIGSET_INTENTS}
+    ...    ${intent}
+    IF    ${is_configset}
+        RETURN    ${intent}-sros-${node}
+    END
+    RETURN    ${intent}-sros

--- a/tests/03-deviations/22-srl-nonrevertive.robot
+++ b/tests/03-deviations/22-srl-nonrevertive.robot
@@ -10,6 +10,7 @@ Resource            ../Keywords/config.robot
 Resource            ../Keywords/gnmic.robot
 Resource            ../Keywords/yq.robot
 Resource            ../Keywords/deviation.robot
+Resource            ../Keywords/intent-routing.robot
 
 Suite Setup         Setup
 Suite Teardown      Run Keyword    Cleanup
@@ -23,315 +24,112 @@ Suite Teardown      Run Keyword    Cleanup
 &{intents}        intent1=vrf1    intent2=vrf2    intent3=vrf3    intent4=vrf4    intent5=vrf5
 &{intentsinterfaces}        intent1=ethernet-1/1    intent2=ethernet-1/2    intent3=ethernet-1/3    intent4=ethernet-1/4    intent5=ethernet-1/5
 ${retry}    2s
+${eventual_timeout}    65sec
 ${options}    --skip-verify -e PROTO
 ${optionsSet}    --skip-verify -e JSON_IETF
+${VERIFY_DEVICE_CONFIG_ON_FULL_ACCEPT}    ${FALSE}
+${INTENT_TARGET_CACHE}    ${None}
 
 *** Test Cases ***
-Create Deviations and Verify non-revertive behavior
-    [Documentation]    Create device deviations and Verify Non-Revertive Deviations on Config(Sets)
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create Deviations and Verify non-revertive behavior - intent1
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent1
+    Run Non-Revertive Scenario For Intent    intent1
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Creating Deviations for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Creating Deviations on ${node} for intent ${intent}
-            # Create a deviation for the intent by applying config directly on the device
-            # Adjust the config on the device using gNMIc
-            Set Config on node via file
-            ...    ${node}
-            ...    ${optionsSet}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/"
-            ...    ${CURDIR}/input/srl/deviations-${intent}.json
-        END
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        # The deviation has been created, now verify the system will not rollback the deviation.
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Confirm in k8s that the config-server picks up the correct count of # deviations.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl-${node}
-                ...    6
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl
-                ...    6
-            END
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl-nonrevertive.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-    END
-    Sleep    10s
+Create Deviations and Verify non-revertive behavior - intent2
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent2
+    Run Non-Revertive Scenario For Intent    intent2
 
-Reject Deviations and Verify revertive behavior
-    [Documentation]    Reject Deviations and Verify Revertive Deviations on Config(Sets)
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create Deviations and Verify non-revertive behavior - intent3
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent3
+    Run Non-Revertive Scenario For Intent    intent3
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        Log    Rejecting Deviations for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Run Keyword
-                ...    Delete Deviation CR
-                ...    ${intent}-srl-${node}
-            ELSE
-                Run Keyword
-                ...    Delete Deviation CR
-                ...    ${intent}-srl
-            END
-        END
-        # Wait some time to allow the system to process the rejection
-        Sleep    5s
-        # The deviation has been rejected, now verify the system will rollback the deviation.
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            # Confirm in k8s that the config-server clears the deviations.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl-${node}
-                ...    0
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl
-                ...    0
-            END
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-    END
-    Sleep    10s
+Create Deviations and Verify non-revertive behavior - intent4
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent4
+    Run Non-Revertive Scenario For Intent    intent4
 
-Create Deviations, Partially accept and Verify, Fully accept and Verify
-    [Documentation]    Create Deviations and Partially accept them on Config(Sets), then fully accept them and Verify
-    @{SDCIO_ALL_INTENTS} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+Create Deviations and Verify non-revertive behavior - intent5
+    [Documentation]    Create deviations and verify non-revertive behavior for a single intent.
+    [Tags]    nonrevertive    create    verify    intent5
+    Run Non-Revertive Scenario For Intent    intent5
 
-    FOR    ${intent}    IN    @{SDCIO_ALL_INTENTS}
-        # CREATE
-        Log    Creating Deviations for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            Log    Creating Deviations on ${node} for intent ${intent}
-            # Create a deviation for the intent by applying config directly on the device
-            # Adjust the config on the device using gNMIc
-            Set Config on node via file
-            ...    ${node}
-            ...    ${optionsSet}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/"
-            ...    ${CURDIR}/input/srl/deviations-${intent}.json
-        END
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl-${node}
-                ...    6
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl
-                ...    6
-            END
-        END
-        # PARTIALLY ACCEPT
-        # Deviations are created, now partially accept them for the intent.
-        kubectl apply    ${CURDIR}/input/srl/${intent}-srl-nonrevertive-partial.yaml
-        # Wait until the deviation is reflected on k8s
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl-${node}
-                ...    3
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl
-                ...    3
-            END
-            # check if config matches here
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl-nonrevertive.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-        # FULLY ACCEPT
-        # Deviations are created, now partially accept them for the intent.
-        kubectl apply    ${CURDIR}/input/srl/${intent}-srl-nonrevertive-full.yaml
-        Log    Verifying Deviations are reflected on k8s for intent ${intent}
-        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-            # If the intent is a ConfigSet, we need to run on all nodes, else we get the targetdevice from the intent yaml.
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                ${targetdevice} =    Set Variable    ${node}
-            ELSE
-                ${rc}    ${targetdevice} =   YQ file    ${CURDIR}/input/srl/${intent}-srl.yaml    '.metadata.labels."config.sdcio.dev/targetName"'
-            END
-            # considering we're looping through all SRL nodes, skip checking for config on nodes that are not defined in the input yaml.
-            IF    '${node}' != '${targetdevice}'
-                Log   Skipping node ${node} as it is not the target device ${targetdevice}
-                Continue For Loop
-            END
-            IF    $intent in $SDCIO_CONFIGSET_INTENTS
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl-${node}
-                ...    0
-            ELSE
-                Wait Until Keyword Succeeds
-                ...    2min
-                ...    ${retry}
-                ...    Verify Deviation on k8s
-                ...    ${intent}-srl
-                ...    0
-            END
-            # check if config matches here
-            @{expectedoutput} =    Load JSON from file    ${CURDIR}/expectedoutput/srl/${intent}-srl-nonrevertive.json
-            # Wait until the deviation is applied on the device using gNMIc
-            Wait Until Keyword Succeeds
-            ...    2min
-            ...    ${retry}
-            ...    Get Config from node and Verify Intent
-            ...    ${node}
-            ...    ${options}
-            ...    ${SRL_USERNAME}
-            ...    ${SRL_PASSWORD}
-            ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
-            ...    ${expectedoutput}
-        END
-    END
+Reject Deviations and Verify revertive behavior - intent1
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent1
+    Run Revertive Scenario For Intent    intent1
+
+Reject Deviations and Verify revertive behavior - intent2
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent2
+    Run Revertive Scenario For Intent    intent2
+
+Reject Deviations and Verify revertive behavior - intent3
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent3
+    Run Revertive Scenario For Intent    intent3
+
+Reject Deviations and Verify revertive behavior - intent4
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent4
+    Run Revertive Scenario For Intent    intent4
+
+Reject Deviations and Verify revertive behavior - intent5
+    [Documentation]    Create deviations, reject them, and verify revertive behavior for a single intent.
+    [Tags]    revertive    reject    verify    intent5
+    Run Revertive Scenario For Intent    intent5
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent1
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent1
+    Run Partial And Full Accept Scenario For Intent    intent1
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent2
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent2
+    Run Partial And Full Accept Scenario For Intent    intent2
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent3
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent3
+    Run Partial And Full Accept Scenario For Intent    intent3
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent4
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent4
+    Run Partial And Full Accept Scenario For Intent    intent4
+
+Create Deviations, Partially accept and Verify, Fully accept and Verify - intent5
+    [Documentation]    Create deviations, partially accept, then fully accept and verify for a single intent.
+    [Tags]    partial-accept    full-accept    verify    intent5
+    Run Partial And Full Accept Scenario For Intent    intent5
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent1
+    [Documentation]    Create deviations, partially revert by interface filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent1
+    Run Partial Revert Scenario For Intent    intent1
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent2
+    [Documentation]    Create deviations, partially revert by interface filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent2
+    Run Partial Revert Scenario For Intent    intent2
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent3
+    [Documentation]    Create deviations, partially revert by interface filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent3
+    Run Partial Revert Scenario For Intent    intent3
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent4
+    [Documentation]    Create deviations, partially revert by interface filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent4
+    Run Partial Revert Scenario For Intent    intent4
+
+Partially Revert Deviations by Filter Path and Verify remaining deviations - intent5
+    [Documentation]    Create deviations, partially revert by interface filter-path, and verify remaining deviations.
+    [Tags]    partial-revert    filter-path    verify    intent5
+    Run Partial Revert Scenario For Intent    intent5
 
 *** Keywords ***
 Setup
@@ -341,9 +139,11 @@ Setup
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml
+        # kubectl get     config ${intent}-srl
         kubectl patch    configset    ${intent}-srl    '{"spec": {"revertive": false}}'
+        # kubectl get     config ${intent}-srl
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    ConfigSet Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
@@ -351,21 +151,24 @@ Setup
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml
+        kubectl get     config ${intent}-srl
         kubectl patch    config    ${intent}-srl    '{"spec": {"revertive": false}}'
+        kubectl get     config ${intent}-srl
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Config Check Ready
         ...    ${SDCIO_RESOURCE_NAMESPACE}
         ...    ${intent}-srl
     END
+    Initialize Intent Target Cache    ${CURDIR}/input/srl    -srl
 
 Cleanup
     Run    echo 'cleanup executed'
     FOR    ${intent}    IN    @{SDCIO_CONFIG_INTENTS}
         Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-srl
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}-srl
@@ -373,7 +176,7 @@ Cleanup
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}-srl
         Wait Until Keyword Succeeds
-        ...    2min
+        ...    ${eventual_timeout}
         ...    ${retry}
         ...    Run Keyword And Expect Error    *
         ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}-srl
@@ -396,3 +199,152 @@ DeleteAll
         ...    ${SRL_PASSWORD}
         ...    "/interface[name=ethernet-1/*]"
     END
+
+Run Non-Revertive Scenario For Intent
+    [Arguments]    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    6
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/srl/${intent}-srl-nonrevertive.json
+
+Run Revertive Scenario For Intent
+    [Arguments]    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    6
+    Reject Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    0
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+
+Run Partial And Full Accept Scenario For Intent
+    [Arguments]    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    6
+    kubectl apply    ${CURDIR}/input/srl/${intent}-srl-nonrevertive-partial.yaml
+    Verify Deviation Count For Intent    ${intent}    3
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/srl/${intent}-srl-nonrevertive.json
+    kubectl apply    ${CURDIR}/input/srl/${intent}-srl-nonrevertive-full.yaml
+    Verify Deviation Count For Intent    ${intent}    0
+    Run Keyword If    ${VERIFY_DEVICE_CONFIG_ON_FULL_ACCEPT}
+    ...    Verify Device Config For Intent
+    ...    ${intent}
+    ...    ${CURDIR}/expectedoutput/srl/${intent}-srl-nonrevertive.json
+
+Run Partial Revert Scenario For Intent
+    [Arguments]    ${intent}
+    Reset Intent Baseline For Intent    ${intent}
+    Create Deviations For Intent    ${intent}
+    Verify Deviation Count For Intent    ${intent}    6
+    Partial Revert Deviations For Intent by Interface    ${intent}
+
+Reset Intent Baseline For Intent
+    [Arguments]    ${intent}
+    kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml
+    ${is_configset} =    Run Keyword And Return Status
+    ...    List Should Contain Value
+    ...    ${SDCIO_CONFIGSET_INTENTS}
+    ...    ${intent}
+    IF    ${is_configset}
+        kubectl patch    configset    ${intent}-srl    '{"spec": {"revertive": false}}'
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    ConfigSet Check Ready
+        ...    ${SDCIO_RESOURCE_NAMESPACE}
+        ...    ${intent}-srl
+        FOR    ${node}    IN    @{SDCIO_SRL_NODES}
+            Wait Until Keyword Succeeds
+            ...    ${eventual_timeout}
+            ...    ${retry}
+            ...    Config Check Ready
+            ...    ${SDCIO_RESOURCE_NAMESPACE}
+            ...    ${intent}-srl-${node}
+        END
+    ELSE
+        kubectl patch    config    ${intent}-srl    '{"spec": {"revertive": false}}'
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Config Check Ready
+        ...    ${SDCIO_RESOURCE_NAMESPACE}
+        ...    ${intent}-srl
+    END
+    Verify Device Config For Intent    ${intent}    ${CURDIR}/expectedoutput/srl/${intent}-srl.json
+
+Create Deviations For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Log    Creating Deviations on ${node} for intent ${intent}
+        Set Config on node via file
+        ...    ${node}
+        ...    ${optionsSet}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/"
+        ...    ${CURDIR}/input/srl/deviations-${intent}.json
+    END
+
+Reject Deviations For Intent
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        ${deviation_name} =    Get Deviation Name    ${intent}    ${node}
+        Delete Deviation    ${deviation_name}
+    END
+
+Verify Deviation Count For Intent
+    [Arguments]    ${intent}    ${expected_count}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        ${deviation_name} =    Get Deviation Name    ${intent}    ${node}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Verify Deviation on k8s
+        ...    ${deviation_name}
+        ...    ${expected_count}
+    END
+
+Verify Device Config For Intent
+    [Arguments]    ${intent}    ${expected_output_file}
+    @{expectedoutput} =    Load JSON from file    ${expected_output_file}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    FOR    ${node}    IN    @{targetnodes}
+        Wait Until Keyword Succeeds
+        ...    ${eventual_timeout}
+        ...    ${retry}
+        ...    Get Config from node and Verify Intent
+        ...    ${node}
+        ...    ${options}
+        ...    ${SRL_USERNAME}
+        ...    ${SRL_PASSWORD}
+        ...    "/network-instance[name=${intents.${intent}}]" --path "/interface[name=${intentsinterfaces.${intent}}]"
+        ...    ${expectedoutput}
+    END
+
+Partial Revert Deviations For Intent by Interface
+    [Arguments]    ${intent}
+    @{targetnodes} =    Get Target Nodes For Intent    ${intent}    ${SDCIO_SRL_NODES}
+    ${targetnode} =    Get From List    ${targetnodes}    0
+    ${deviation_name} =    Get Deviation Name    ${intent}    ${targetnode}
+    ${interface_path} =    Set Variable    /interface[name=${intentsinterfaces.${intent}}]
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    kubectl sdc deviation --deviation ${deviation_name} --filter-path ${interface_path} --revert
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Wait Until Keyword Succeeds
+    ...    ${eventual_timeout}
+    ...    ${retry}
+    ...    Verify Deviation on k8s
+    ...    ${deviation_name}
+    ...    3
+
+Get Deviation Name
+    [Arguments]    ${intent}    ${node}
+    ${is_configset} =    Run Keyword And Return Status
+    ...    List Should Contain Value
+    ...    ${SDCIO_CONFIGSET_INTENTS}
+    ...    ${intent}
+    IF    ${is_configset}
+        RETURN    ${intent}-srl-${node}
+    END
+    RETURN    ${intent}-srl

--- a/tests/03-deviations/input/sros/customer.yaml
+++ b/tests/03-deviations/input/sros/customer.yaml
@@ -17,5 +17,7 @@ spec:
           customer:
             - customer-name: "1"
               customer-id: 1
+              description: "mumafoobar"
             - customer-name: "2"
               customer-id: 2
+              description: "other"

--- a/tests/Keywords/config.robot
+++ b/tests/Keywords/config.robot
@@ -11,8 +11,8 @@ Config Check Ready
     ${rc}    ${output} =    kubectl get    -n ${namespace} configs.config.sdcio.dev -o=json ${object}
     Log    ${output}
     ${json} =    Convert string to JSON    ${output}
-    ${status} =    Get values from JSON    ${json}    $.status.conditions[*].status
-    Should be equal as strings    ${status}    ['True', 'True', 'True']
+    ${status} =    Get values from JSON    ${json}    $.status.conditions[?(@.type=='Ready')].status
+    Should be equal as strings    ${status}    ['True']
 
 ConfigSet Check Ready
     [Documentation]    Make sure the referenced ConfigSet is applied properly
@@ -21,7 +21,7 @@ ConfigSet Check Ready
     ${rc}    ${output} =    kubectl get    -n ${namespace} configsets.config.sdcio.dev -o=json ${object}
     Log    ${output}
     ${json} =    Convert string to JSON    ${output}
-    ${status} =    Get values from JSON    ${json}    $.status.conditions[*].status
+    ${status} =    Get values from JSON    ${json}    $.status.conditions[?(@.type=='Ready')].status
     Should be equal as strings    ${status}    ['True']
 
 Delete Config

--- a/tests/Keywords/deviation.robot
+++ b/tests/Keywords/deviation.robot
@@ -19,7 +19,7 @@ Verify Deviation on k8s
     Should Be Equal As Integers    ${rc}    0
     Should Be Equal As Integers    ${result}    ${match}
 
-Delete Deviation CR
+Delete Deviation
     [Documentation]    Delete the deviation CR on k8s
     [Arguments]    ${name}
     ${rc}    ${output} =    Run And Return Rc And Output

--- a/tests/Keywords/discovery.robot
+++ b/tests/Keywords/discovery.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Library     OperatingSystem
+Resource    ../variables.robot
+Resource    k8s/kubectl.robot
+
+
+*** Keywords ***
+Apply Discovery Rules
+    [Arguments]    @{rule_files}
+    FOR    ${rule_file}    IN    @{rule_files}
+        kubectl apply    ${rule_file}
+    END
+
+Delete Discovery Rules If Present
+    [Arguments]    @{rule_names}
+    FOR    ${rule_name}    IN    @{rule_names}
+        ${rc}    ${output} =    Run And Return Rc And Output
+        ...    kubectl get -n ${SDCIO_RESOURCE_NAMESPACE} discoveryrules.inv.sdcio.dev ${rule_name}
+        IF    ${rc} == 0
+            ${rc}    ${output} =    Run And Return Rc And Output
+            ...    kubectl delete -n ${SDCIO_RESOURCE_NAMESPACE} discoveryrules.inv.sdcio.dev ${rule_name}
+            Log    ${output}
+            Should Be Equal As Integers    ${rc}    0
+        END
+    END

--- a/tests/Keywords/intent-routing.robot
+++ b/tests/Keywords/intent-routing.robot
@@ -1,0 +1,79 @@
+*** Settings ***
+Library             Collections
+Resource            config.robot
+Resource            yq.robot
+Resource            k8s/kubectl.robot
+
+*** Variables ***
+${eventual_timeout}    2min
+${retry}               10s
+
+*** Keywords ***
+Initialize Intent Target Cache
+    [Documentation]    Build a cache mapping each intent to its target node (or "ALL" for ConfigSets).
+    ...    Arguments:
+    ...      input_dir     — absolute path to the directory holding intent YAML files (e.g. ${CURDIR}/input/sros)
+    ...      intent_suffix — filename suffix identifying the platform (e.g. -sros or -srl)
+    [Arguments]    ${input_dir}    ${intent_suffix}
+    @{all_intents} =    Combine Lists    ${SDCIO_CONFIGSET_INTENTS}    ${SDCIO_CONFIG_INTENTS}
+    &{cache} =    Create Dictionary
+    FOR    ${intent}    IN    @{all_intents}
+        ${is_configset} =    Run Keyword And Return Status
+        ...    List Should Contain Value    ${SDCIO_CONFIGSET_INTENTS}    ${intent}
+        IF    ${is_configset}
+            Set To Dictionary    ${cache}    ${intent}=ALL
+        ELSE
+            ${rc}    ${targetdevice} =    YQ file
+            ...    ${input_dir}/${intent}${intent_suffix}.yaml
+            ...    '.metadata.labels."config.sdcio.dev/targetName"'
+            Should Be Equal As Integers    ${rc}    0
+            Set To Dictionary    ${cache}    ${intent}=${targetdevice}
+        END
+    END
+    Set Suite Variable    ${INTENT_TARGET_CACHE}    ${cache}
+
+Get Target Nodes For Intent
+    [Documentation]    Return the list of nodes that an intent targets.
+    ...    ConfigSet intents return all_nodes; Config intents return a single-element list.
+    [Arguments]    ${intent}    ${all_nodes}
+    ${target_mode} =    Get From Dictionary    ${INTENT_TARGET_CACHE}    ${intent}
+    IF    '${target_mode}' == 'ALL'
+        RETURN    @{all_nodes}
+    END
+    @{targetnodes} =    Create List    ${target_mode}
+    RETURN    @{targetnodes}
+
+Apply Intent On K8s
+    [Documentation]    Apply an intent YAML and wait for the k8s resource to reach Ready state.
+    ...    Arguments:
+    ...      intent       — intent name (e.g. intent1)
+    ...      file_suffix  — file-name suffix after the name_suffix (e.g. ${EMPTY}, -update, -replace)
+    ...      input_dir    — path to directory holding intent YAML files
+    ...      name_suffix  — platform suffix used in the k8s resource name (e.g. -sros, -srl)
+    [Arguments]    ${intent}    ${file_suffix}    ${input_dir}    ${name_suffix}
+    ${rc}    ${output} =    kubectl apply    ${input_dir}/${intent}${name_suffix}${file_suffix}.yaml
+    IF    $intent in $SDCIO_CONFIGSET_INTENTS
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}${name_suffix}
+    ELSE
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Config Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}${name_suffix}
+    END
+
+Delete Intent From K8s
+    [Documentation]    Delete an intent from k8s and wait until the resource is gone.
+    ...    Arguments:
+    ...      intent      — intent name (e.g. intent1)
+    ...      name_suffix — platform suffix used in the k8s resource name (e.g. -sros, -srl)
+    [Arguments]    ${intent}    ${name_suffix}
+    IF    $intent in $SDCIO_CONFIGSET_INTENTS
+        ${rc}    ${output} =    Delete ConfigSet    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}${name_suffix}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Run Keyword And Expect Error    *
+        ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configsets.config.sdcio.dev ${intent}${name_suffix}
+    ELSE
+        ${rc}    ${output} =    Delete Config    ${SDCIO_RESOURCE_NAMESPACE}    ${intent}${name_suffix}
+        Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}
+        ...    Run Keyword And Expect Error    *
+        ...    kubectl get    -n ${SDCIO_RESOURCE_NAMESPACE} configs.config.sdcio.dev ${intent}${name_suffix}
+    END

--- a/tests/Keywords/targets.robot
+++ b/tests/Keywords/targets.robot
@@ -13,3 +13,16 @@ Targets Check Ready
     ${json} =    Convert string to JSON    ${output}
     ${status} =    Get values from JSON    ${json}    $.conditions[*].status
     Should be equal as strings    ${status}    ['True', 'True', 'True', 'True', 'True']
+
+Target Check Ready With Profiles
+    [Documentation]    Make sure the discovered Target is ready and uses the expected connection and sync profiles
+    [Arguments]    ${namespace}    ${node}    ${connection_profile}    ${sync_profile}
+    ${rc}    ${output} =    kubectl get    -n ${namespace} targets.config.sdcio.dev -o=json ${node}
+    Log     ${output}
+    ${json} =    Convert string to JSON    ${output}
+    ${status} =    Get values from JSON    ${json}    $.status.conditions[*].status
+    Should be equal as strings    ${status}    ['True', 'True', 'True', 'True', 'True']
+    ${target_connection_profile} =    Get values from JSON    ${json}    $.spec.connectionProfile
+    Should be equal as strings    ${target_connection_profile}    ['${connection_profile}']
+    ${target_sync_profile} =    Get values from JSON    ${json}    $.spec.syncProfile
+    Should be equal as strings    ${target_sync_profile}    ['${sync_profile}']

--- a/tests/variables.robot
+++ b/tests/variables.robot
@@ -52,7 +52,8 @@ ${SDCIO_INTEGRATION_TESTS_TARGETSYNCPROFILE_FILES_BASE}             ${CURDIR}/01
 ...                                                                 sync_profile_sros_gnmi.yaml
 ...                                                                 sync_profile_sros_gnmi_onchange.yaml
 ...                                                                 sync_profile_srl_gnmi_get.yaml
-...                                                                 sync_profile_srl_gnmi_onchange.yaml    
+...                                                                 sync_profile_srl_gnmi_onchange.yaml
+...                                                                 sync_profile_srl_gnmi_onchange_jsonietf.yaml
 
 # DiscoveryVendorProfiles
 ${SDCIO_CONFIG_SERVER_DISCOVERYVENDORPROFILE_FILES_BASE}	${SDCIO_CONFIG_SERVER_REPO_PATH}/example/discoveryvendor-profile


### PR DESCRIPTION
- Refactor 22-srl-nonrevertive.robot and 21-sros-nonrevertive.robot: replace single intent-loop test cases with individual tagged test cases per intent, enabling per-intent execution and better failure isolation
- Fix race in Reset Intent Baseline For Intent: ConfigSet Check Ready returned True before per-node reconcilers finished syncing the device, causing Create Deviations For Intent to see 0 deviations instead of 6
- Add per-node Config Check Ready wait after ConfigSet reset
- Add device-state baseline verification (Verify Device Config For Intent) before creating deviations to guarantee a clean starting state
- Add new test suites: 13-srl-onchange-encodings, 14-sros-onchange-sync
- Add intent-routing keyword library with intent/target cache helpers
- Add new discovery and sync profiles for onchange scenarios
- Add miscellaneous supporting input and resource files