### PR TITLE
ci: add integration_tests_ref input to reusable single.yml workflow

### DIFF
--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -205,6 +205,53 @@ jobs:
           [ -f /tmp/api-server-pid.txt ] && kill $(cat /tmp/api-server-pid.txt) 2>/dev/null || true
           sleep 1
 
+      # Runs any numbered suites beyond 03 that are present in the checked-out integration-tests
+      # branch (e.g. 04-sensitive, 05-foo). Suites 00-03 above are handled by explicit steps.
+      # This step is a no-op when no additional suites exist, so merging it to main once is enough
+      # — feature branches that add new suites are picked up automatically via integration_tests_ref.
+      - name: Run Robot Tests 04+ - Additional suites (auto-discovered)
+        run: |
+          shopt -s nullglob
+          additional=( ./integration-tests/tests/0[4-9]-* ./integration-tests/tests/[1-9][0-9]-* )
+          if [ ${#additional[@]} -eq 0 ]; then
+            echo "No additional test suites found (04+), skipping."
+            exit 0
+          fi
+          for dir in "${additional[@]}"; do
+            [ -d "$dir" ] || continue
+            suite=$(basename "$dir")
+            echo "=== Running suite: ${suite} ==="
+            mkdir -p "./integration-tests/tests/out/${suite}-logs"
+
+            kubectl logs -f statefulset/data-server-controller -c data-server \
+              -n ${{ env.SDC_NAMESPACE }} --tail=0 --since=0s \
+              > "./integration-tests/tests/out/${suite}-logs/data-server.log" 2>&1 &
+            echo $! > /tmp/extra-ds-pid.txt
+
+            kubectl logs -f statefulset/data-server-controller -c controller \
+              -n ${{ env.SDC_NAMESPACE }} --tail=0 --since=0s \
+              > "./integration-tests/tests/out/${suite}-logs/data-server-controller.log" 2>&1 &
+            echo $! > /tmp/extra-dsc-pid.txt
+
+            kubectl logs -f deployment/api-server -c api-server \
+              -n ${{ env.SDC_NAMESPACE }} --tail=0 --since=0s \
+              > "./integration-tests/tests/out/${suite}-logs/api-server.log" 2>&1 &
+            echo $! > /tmp/extra-api-pid.txt
+
+            robot --consolecolors on -r none \
+              -l  "./integration-tests/tests/out/${suite}-log" \
+              --output "./integration-tests/tests/out/${suite}-out.xml" \
+              "$dir"
+            ROBOT_RC=$?
+
+            [ -f /tmp/extra-ds-pid.txt ]  && kill "$(cat /tmp/extra-ds-pid.txt)"  2>/dev/null || true
+            [ -f /tmp/extra-dsc-pid.txt ] && kill "$(cat /tmp/extra-dsc-pid.txt)" 2>/dev/null || true
+            [ -f /tmp/extra-api-pid.txt ] && kill "$(cat /tmp/extra-api-pid.txt)" 2>/dev/null || true
+            sleep 1
+
+            [ $ROBOT_RC -ne 0 ] && exit $ROBOT_RC
+          done
+
       # upload test reports as a zip file
       - name: Upload test reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -23,6 +23,14 @@ on:
         description: "cert-manager release (vX.Y.Z)"
         required: true
         type: string
+      integration_tests_ref:
+        description: >
+          Branch, tag, or SHA of sdcio/integration-tests to check out for test execution.
+          Defaults to main. Set via Pairs-with: sdcio/integration-tests#NNN in PR body
+          to test feature-branch Robot suites alongside paired data-server/config-server changes.
+        required: false
+        default: "main"
+        type: string
 env:
   PY_VER: "3.10"
   GO_VER: "1.25.8"
@@ -48,6 +56,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: sdcio/integration-tests
+          ref: ${{ inputs.integration_tests_ref }}
           path: integration-tests
 
       - name: Checkout config-server


### PR DESCRIPTION
## Summary

Adds an optional `integration_tests_ref` input to the reusable `single.yml` workflow so callers can check out a feature branch of `integration-tests` instead of always pinning to `main`.

- **Default is `main`** — all existing callers (`matrix-cicd.yml`, `cicd.yml` in data-server/config-server) are unaffected until they explicitly pass the input.
- Callers resolve the ref from a `Pairs-with: sdcio/integration-tests#NNN` line in their PR body (see companion PRs in data-server and config-server).
- The workflow *definition* (`single.yml`) always comes from `@main` (GitHub Actions limitation on dynamic `uses:` refs), but the test *code* (Robot suites, keywords, fixtures) is checked out at the specified ref, which is all that's needed for new or modified test cases.

## How it fits the cross-repo pairing flow

```
data-server PR body:
  Pairs-with: sdcio/config-server#455
  Pairs-with: sdcio/integration-tests#42   ← new

data-server CI resolves both PR numbers → branch names → passes to single.yml
single.yml checks out integration-tests at the feature branch → runs those Robot files
```

## Merge order

**This PR must be merged before** the companion data-server and config-server PRs start passing `integration_tests_ref`, otherwise GitHub Actions will reject the unknown input.

## Test plan

- Verify `matrix-cicd.yml` (uses `single.yml` locally without the input) still works — no change needed, input defaults to `main`.
- Verify a caller that passes `integration_tests_ref: some-branch` checks out that branch for the Robot test execution.

Made with [Cursor](https://cursor.com)