### PR TITLE
fix(ci): avoid false failure in 04+ suites step

### DIFF
--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -249,7 +249,7 @@ jobs:
             [ -f /tmp/extra-api-pid.txt ] && kill "$(cat /tmp/extra-api-pid.txt)" 2>/dev/null || true
             sleep 1
 
-            [ $ROBOT_RC -ne 0 ] && exit $ROBOT_RC
+            if [ "$ROBOT_RC" -ne 0 ]; then exit "$ROBOT_RC"; fi
           done
 
       # upload test reports as a zip file


### PR DESCRIPTION
## Summary
- fix the 04+ auto-discovered suites loop to avoid `bash -e` false failures when `ROBOT_RC=0`
- replace `[ $ROBOT_RC -ne 0 ] && exit $ROBOT_RC` with an explicit `if ... fi` guard
- this keeps CI green when Robot reports pass/skip only

## Test plan
- [x] Verify branch diff only updates `.github/workflows/single.yml`
- [x] Confirm logic now exits non-zero only when Robot returns non-zero
- [ ] Re-run config-server CI job that uses `sdcio/integration-tests/.github/workflows/single.yml@main`

Made with [Cursor](https://cursor.com)