### PR TITLE
test: add target-discovery diagnostics on readiness timeout

### DIFF
--- a/tests/02-crud/11-sros-create-delete.robot
+++ b/tests/02-crud/11-sros-create-delete.robot
@@ -73,7 +73,7 @@ Delete ConfigSet with orphan policy keeps device config on all targets - intent1
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    2min    10s    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"

--- a/tests/02-crud/12-srl-create-delete.robot
+++ b/tests/02-crud/12-srl-create-delete.robot
@@ -79,7 +79,7 @@ Delete ConfigSet with orphan policy keeps device config on all targets - intent1
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     Initialize Intent Target Cache    ${CURDIR}/input/srl    -srl
 

--- a/tests/02-crud/21-sros-update-replace.robot
+++ b/tests/02-crud/21-sros-update-replace.robot
@@ -65,7 +65,7 @@ Replace And Verify intent4
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    2min    10s    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"

--- a/tests/02-crud/22-srl-update-replace.robot
+++ b/tests/02-crud/22-srl-update-replace.robot
@@ -71,7 +71,7 @@ Replace And Verify intent5
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml

--- a/tests/03-deviations/11-sros-revertive.robot
+++ b/tests/03-deviations/11-sros-revertive.robot
@@ -78,7 +78,7 @@ Adjust SROS device config and Verify Revertive Deviations - intent4
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    5min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}    timeout=5min    retry=${retry}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"

--- a/tests/03-deviations/12-srl-revertive.robot
+++ b/tests/03-deviations/12-srl-revertive.robot
@@ -90,7 +90,7 @@ Adjust SRL device config and Verify Revertive Deviations - intent5
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}    retry=${retry}
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml

--- a/tests/03-deviations/21-sros-nonrevertive.robot
+++ b/tests/03-deviations/21-sros-nonrevertive.robot
@@ -114,7 +114,7 @@ Partially Revert Deviations by Filter Path and Verify remaining deviations - int
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds

--- a/tests/03-deviations/22-srl-nonrevertive.robot
+++ b/tests/03-deviations/22-srl-nonrevertive.robot
@@ -135,7 +135,7 @@ Partially Revert Deviations by Filter Path and Verify remaining deviations - int
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}    retry=${retry}
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml

--- a/tests/Keywords/targets.robot
+++ b/tests/Keywords/targets.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource    k8s/kubectl.robot
+Resource    ../variables.robot
 Library     RPA.JSON
 
 
@@ -13,6 +14,33 @@ Targets Check Ready
     ${json} =    Convert string to JSON    ${output}
     ${status} =    Get values from JSON    ${json}    $.conditions[*].status
     Should be equal as strings    ${status}    ['True', 'True', 'True', 'True', 'True']
+
+Wait Until Target Ready
+    [Documentation]    Waits for a Target to report all conditions ready. On timeout, dumps
+    ...    discovery diagnostics (Target list, DiscoveryRule status, api-server logs) before
+    ...    failing with a clear message — instead of the opaque "1 != 0" a raw
+    ...    "Wait Until Keyword Succeeds" + "Should Be Equal As Strings" failure produces.
+    ...    Common root cause covered by this: the Target CR is never created at all
+    ...    (discovery never finds the device) rather than being created-but-not-ready;
+    ...    the diagnostics below distinguish the two.
+    [Arguments]    ${namespace}    ${node}    ${timeout}=15min    ${retry}=10s
+    ${ready} =    Run Keyword And Return Status
+    ...    Wait Until Keyword Succeeds    ${timeout}    ${retry}    Targets Check Ready    ${namespace}    ${node}
+    IF    not ${ready}
+        Log Target discovery diagnostics    ${namespace}    ${node}
+        Fail    Target '${node}' not ready within ${timeout} - see discovery diagnostics above (logged at WARN)
+    END
+
+Log Target discovery diagnostics
+    [Documentation]    Best-effort snapshot of discovery/target state when a Target fails to
+    ...    become ready in time. Logged at WARN so it is visible without verbose mode.
+    [Arguments]    ${namespace}    ${node}
+    Log    === Target/Discovery diagnostics for '${node}' ===    WARN
+    Kubectl log diagnostic    get targets.config.sdcio.dev -n ${namespace} -o wide
+    Kubectl log diagnostic    get targets.config.sdcio.dev ${node} -n ${namespace} -o yaml
+    Kubectl log diagnostic    get discoveryrules.inv.sdcio.dev -n ${namespace} -o yaml
+    Kubectl log diagnostic    get pods -n ${SDCIO_SYSTEM_NAMESPACE} -o wide
+    Kubectl log diagnostic    logs deployment/api-server -n ${SDCIO_SYSTEM_NAMESPACE} -c api-server --tail=500
 
 Target Check Ready With Profiles
     [Documentation]    Make sure the discovered Target is ready and uses the expected connection and sync profiles


### PR DESCRIPTION
## Summary
- `Targets Check Ready` failures currently surface as an opaque `1 != 0` after a full 15-minute `Wait Until Keyword Succeeds`, with no signal on *why* — in particular no way to tell whether the `Target` CR was never created (discovery never found the device) versus created-but-not-ready.
- Adds `Wait Until Target Ready` in `tests/Keywords/targets.robot`: same wait behavior, but on timeout it dumps `Target`/`DiscoveryRule` state and `api-server` logs at `WARN` before failing with a clear message.
- Switches all 8 existing call sites (`02-crud`, `03-deviations`) to the new keyword. No timeout/retry values changed — this is diagnostics-only, not a behavior change.

Split out of the `sensitive` data-server/config-server pairing (sdcio/data-server#460) investigation into recent SROS `Targets Check Ready` timeouts, so this can merge independently and unblock CI diagnostics for any other in-flight PR hitting the same timeout (e.g. sdcio/data-server#466).

Note: an actual discovery-mechanism change (switching `sr2`'s DiscoveryRule from a `/28` prefix scan to address-based) was tried and reverted — per project docs, unreachable-target connection errors during range scanning are expected/by-design, so that change was not the right fix. This PR only adds visibility so the next occurrence is diagnosable.

## Test plan
- [x] `robot --dryrun` across all 9 touched suites — 100/100 test cases pass (keyword resolution / imports valid)
- [ ] Confirm on a real CI run that the diagnostics WARN block actually surfaces useful data if `Targets Check Ready` times out again

Made with [Cursor](https://cursor.com)