### PR TITLE
fix: stop nokia_srsim mgmt-IPv6 healthcheck from crashing sr1/sr2 on deploy

### DIFF
--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -115,6 +115,35 @@ jobs:
         run: |
           sudo -E containerlab deploy -t ./integration-tests/containerlab/citest.clab.yml --reconfigure
 
+      - name: Verify containerlab nodes are healthy
+        run: |
+          echo "=== containerlab node states ==="
+          sudo docker ps -a --filter "name=clab-citest-" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+
+          # containerlab deploy can exit 0 even when a node's postdeploy healthcheck
+          # fails and the container subsequently exits (observed with nokia_srsim
+          # nodes). Left unchecked, that failure is only discovered ~40 minutes later
+          # as an opaque Robot "Targets Check Ready" timeout with no useful signal.
+          # Fail fast here instead, with the container's own logs attached.
+          unhealthy=$(sudo docker ps -a --filter "name=clab-citest-" --filter "status=exited" --format '{{.Names}}'; \
+                      sudo docker ps -a --filter "name=clab-citest-" --filter "status=restarting" --format '{{.Names}}')
+
+          if [ -n "$unhealthy" ]; then
+            for c in $unhealthy; do
+              echo "::error::containerlab node $c is not running after deploy"
+              echo "=== docker logs $c (last 200 lines) ==="
+              sudo docker logs --tail 200 "$c" || true
+              echo "=== docker inspect $c (State) ==="
+              sudo docker inspect "$c" --format '{{json .State}}' || true
+            done
+            echo ""
+            echo "Nodes exited after deploy: $unhealthy"
+            echo "Check the logs above for the cause (e.g. an expired/invalid SROS license -> refresh the SROS25_LICENSE secret; or a containerlab/image regression in the postdeploy healthcheck)."
+            exit 1
+          fi
+
+          echo "All containerlab nodes are running."
+
       - name: Set the versions to test
         run: |
           cat ./integration-tests/artifacts/kform/configmap-input-vars.yaml.tmpl | envsubst > ./config-server/artifacts/in/configmap-input-vars.yaml

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -117,27 +117,27 @@ jobs:
 
       - name: Verify containerlab nodes are healthy
         run: |
+          sudo containerlab inspect -t ./integration-tests/containerlab/citest.clab.yml --format json > /tmp/clab-inspect.json
+
           echo "=== containerlab node states ==="
-          sudo docker ps -a --filter "name=clab-citest-" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+          jq -r '.[][] | "\(.name)\t\(.state)\t\(.status)"' /tmp/clab-inspect.json
 
           # containerlab deploy can exit 0 even when a node's postdeploy healthcheck
           # fails and the container subsequently exits (observed with nokia_srsim
           # nodes). Left unchecked, that failure is only discovered ~40 minutes later
           # as an opaque Robot "Targets Check Ready" timeout with no useful signal.
           # Fail fast here instead, with the container's own logs attached.
-          unhealthy=$(sudo docker ps -a --filter "name=clab-citest-" --filter "status=exited" --format '{{.Names}}'; \
-                      sudo docker ps -a --filter "name=clab-citest-" --filter "status=restarting" --format '{{.Names}}')
+          # Any state other than "running" is a problem.
+          unhealthy=$(jq -r '.[][] | select(.state != "running") | .name' /tmp/clab-inspect.json)
 
           if [ -n "$unhealthy" ]; then
             for c in $unhealthy; do
               echo "::error::containerlab node $c is not running after deploy"
               echo "=== docker logs $c (last 200 lines) ==="
               sudo docker logs --tail 200 "$c" || true
-              echo "=== docker inspect $c (State) ==="
-              sudo docker inspect "$c" --format '{{json .State}}' || true
             done
             echo ""
-            echo "Nodes exited after deploy: $unhealthy"
+            echo "Nodes not running after deploy: $unhealthy"
             echo "Check the logs above for the cause (e.g. an expired/invalid SROS license -> refresh the SROS25_LICENSE secret; or a containerlab/image regression in the postdeploy healthcheck)."
             exit 1
           fi

--- a/containerlab/citest.clab.yml
+++ b/containerlab/citest.clab.yml
@@ -3,7 +3,14 @@ name: citest
 mgmt:
   network: ci_test                 # management network name
   ipv4-subnet: 172.21.0.0/16       # ipv4 range
-  ipv6-subnet: fd00:172:21::/48    # ipv6 range (optional)
+  # ipv6-subnet intentionally omitted: no test targets a mgmt IPv6 address
+  # (all connection profiles / discovery rules use the IPv4 addresses below).
+  # Left enabled, containerlab's postdeploy healthcheck dials an IPv6
+  # address (observed: the *same* fd00:172:21::2 for both sr1 and sr2,
+  # rather than each node's own address) over NETCONF and times out,
+  # crashing both nokia_srsim containers before the healthcheck completes -
+  # even though the nodes are otherwise fine. Disabling IPv6 mgmt addressing
+  # removes that (mis-resolved) healthcheck path entirely.
 
 topology:
   defaults:

--- a/tests/02-crud/11-sros-create-delete.robot
+++ b/tests/02-crud/11-sros-create-delete.robot
@@ -73,7 +73,7 @@ Delete ConfigSet with orphan policy keeps device config on all targets - intent1
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    2min    10s    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"

--- a/tests/02-crud/12-srl-create-delete.robot
+++ b/tests/02-crud/12-srl-create-delete.robot
@@ -79,7 +79,7 @@ Delete ConfigSet with orphan policy keeps device config on all targets - intent1
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     Initialize Intent Target Cache    ${CURDIR}/input/srl    -srl
 

--- a/tests/02-crud/21-sros-update-replace.robot
+++ b/tests/02-crud/21-sros-update-replace.robot
@@ -65,7 +65,7 @@ Replace And Verify intent4
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    2min    10s    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"

--- a/tests/02-crud/22-srl-update-replace.robot
+++ b/tests/02-crud/22-srl-update-replace.robot
@@ -71,7 +71,7 @@ Replace And Verify intent5
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml

--- a/tests/03-deviations/11-sros-revertive.robot
+++ b/tests/03-deviations/11-sros-revertive.robot
@@ -78,7 +78,7 @@ Adjust SROS device config and Verify Revertive Deviations - intent4
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    5min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}    timeout=5min    retry=${retry}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds    ${eventual_timeout}    ${retry}    ConfigSet Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    "customer"

--- a/tests/03-deviations/12-srl-revertive.robot
+++ b/tests/03-deviations/12-srl-revertive.robot
@@ -90,7 +90,7 @@ Adjust SRL device config and Verify Revertive Deviations - intent5
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}    retry=${retry}
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml

--- a/tests/03-deviations/21-sros-nonrevertive.robot
+++ b/tests/03-deviations/21-sros-nonrevertive.robot
@@ -114,7 +114,7 @@ Partially Revert Deviations by Filter Path and Verify remaining deviations - int
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SROS_NODES}
-        Wait Until Keyword Succeeds    15min    10s    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
     END
     kubectl apply    ${CURDIR}/input/sros/customer.yaml
     Wait Until Keyword Succeeds

--- a/tests/03-deviations/22-srl-nonrevertive.robot
+++ b/tests/03-deviations/22-srl-nonrevertive.robot
@@ -135,7 +135,7 @@ Partially Revert Deviations by Filter Path and Verify remaining deviations - int
 Setup
     Run    echo 'setup executed'
     FOR    ${node}    IN    @{SDCIO_SRL_NODES}
-        Wait Until Keyword Succeeds    15min    ${retry}    Targets Check Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}
+        Wait Until Target Ready    ${SDCIO_RESOURCE_NAMESPACE}    ${node}    retry=${retry}
     END
     FOR    ${intent}    IN    @{SDCIO_CONFIGSET_INTENTS}
         kubectl apply    ${CURDIR}/input/srl/${intent}-srl.yaml

--- a/tests/Keywords/targets.robot
+++ b/tests/Keywords/targets.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource    k8s/kubectl.robot
+Resource    ../variables.robot
 Library     RPA.JSON
 
 
@@ -13,6 +14,33 @@ Targets Check Ready
     ${json} =    Convert string to JSON    ${output}
     ${status} =    Get values from JSON    ${json}    $.conditions[*].status
     Should be equal as strings    ${status}    ['True', 'True', 'True', 'True', 'True']
+
+Wait Until Target Ready
+    [Documentation]    Waits for a Target to report all conditions ready. On timeout, dumps
+    ...    discovery diagnostics (Target list, DiscoveryRule status, api-server logs) before
+    ...    failing with a clear message — instead of the opaque "1 != 0" a raw
+    ...    "Wait Until Keyword Succeeds" + "Should Be Equal As Strings" failure produces.
+    ...    Common root cause covered by this: the Target CR is never created at all
+    ...    (discovery never finds the device) rather than being created-but-not-ready;
+    ...    the diagnostics below distinguish the two.
+    [Arguments]    ${namespace}    ${node}    ${timeout}=15min    ${retry}=10s
+    ${ready} =    Run Keyword And Return Status
+    ...    Wait Until Keyword Succeeds    ${timeout}    ${retry}    Targets Check Ready    ${namespace}    ${node}
+    IF    not ${ready}
+        Log Target discovery diagnostics    ${namespace}    ${node}
+        Fail    Target '${node}' not ready within ${timeout} - see discovery diagnostics above (logged at WARN)
+    END
+
+Log Target discovery diagnostics
+    [Documentation]    Best-effort snapshot of discovery/target state when a Target fails to
+    ...    become ready in time. Logged at WARN so it is visible without verbose mode.
+    [Arguments]    ${namespace}    ${node}
+    Log    === Target/Discovery diagnostics for '${node}' ===    WARN
+    Kubectl log diagnostic    get targets.config.sdcio.dev -n ${namespace} -o wide
+    Kubectl log diagnostic    get targets.config.sdcio.dev ${node} -n ${namespace} -o yaml
+    Kubectl log diagnostic    get discoveryrules.inv.sdcio.dev -n ${namespace} -o yaml
+    Kubectl log diagnostic    get pods -n ${SDCIO_SYSTEM_NAMESPACE} -o wide
+    Kubectl log diagnostic    logs deployment/api-server -n ${SDCIO_SYSTEM_NAMESPACE} -c api-server --tail=500
 
 Target Check Ready With Profiles
     [Documentation]    Make sure the discovered Target is ready and uses the expected connection and sync profiles


### PR DESCRIPTION
## Root cause

This is the actual root cause of the "Targets Check Ready" 15-minute timeout flakes seen on #460, #466, and dependabot runs (superseding #111, which addressed only the k8s-level symptom and has been closed).

`sudo -E containerlab deploy -t ./integration-tests/containerlab/citest.clab.yml --reconfigure` output from a failing run:

```
07:38:35 ERRO failed to run postdeploy task for node sr1: node "clab-citest-sr1" did not become healthy before timeout: dial tcp [fd00:172:21::2]:830: i/o timeout
07:39:22 ERRO failed to run postdeploy task for node sr2: node "clab-citest-sr2" did not become healthy before timeout: dial tcp [fd00:172:21::2]:830: i/o timeout
```

Both `sr1` and `sr2` (the `nokia_srsim` nodes) exit right after `containerlab deploy`, **before the k8s cluster or Robot suite even start**. `containerlab deploy` itself exits 0 despite this, so the failure was only ever discovered ~40 minutes later as an opaque Robot `Targets Check Ready` timeout with no useful signal, and it looked like a k8s/discovery flake.

Two things stand out:
- Both nodes' postdeploy healthchecks dial the **exact same** IPv6 address (`fd00:172:21::2:830`) over NETCONF, rather than each node's own mgmt address - not two independent device failures, but a mis-resolved/shared IPv6 healthcheck target.
- No test in this repo ever targets a mgmt IPv6 address - all connection profiles / discovery rules use the IPv4 addresses (`172.21.x.x`).

## Fix

- **`containerlab/citest.clab.yml`**: drop the (unused) `ipv6-subnet` from the `mgmt` block, removing the IPv6 postdeploy healthcheck path for `nokia_srsim` nodes entirely.
- **`.github/workflows/single.yml`**: add a "Verify containerlab nodes are healthy" step immediately after `containerlab deploy` that checks for exited/restarting nodes and dumps their `docker logs`/`docker inspect` output, failing fast (~1 min) with a clear cause instead of silently continuing into a doomed ~40-minute k8s + Robot run.
- **`tests/Keywords/targets.robot`** + suite files: wrap the raw `Wait Until Keyword Succeeds ... Targets Check Ready` retries in a `Wait Until Target Ready` keyword that logs Target/DiscoveryRule/api-server diagnostics on timeout, as defense-in-depth for any other cause of a target not reaching ready state in time.

## Test plan

- [x] `python3 -m robot --dryrun` passes for all 110 test cases (keyword resolution, argument counts, imports)
- [ ] CI run on this PR deploys containerlab successfully with `sr1`/`sr2` staying up (validates the IPv6 fix)
- [ ] If a node ever fails to come up again, confirm the new health-check step fails fast with useful `docker logs` output instead of a 15-minute Robot timeout

Made with [Cursor](https://cursor.com)