### PR TITLE
fix(ci): provision config-keyring Secret before waiting on data-server-controller

### DIFF
--- a/tests/00-setup/02-artifacts.robot
+++ b/tests/00-setup/02-artifacts.robot
@@ -7,3 +7,12 @@ Resource            ../Keywords/k8s/kubectl.robot
 Install SDCIO
     kubectl apply     ./config-server/artifacts/out/artifacts.yaml
 
+Install CI keyring secret
+    [Documentation]    config-server no longer ships a default config-keyring
+    ...    Secret in its own deploy artifacts (by design, to force real
+    ...    deployments to bring their own key material). The data-server
+    ...    StatefulSets mount this Secret as a volume regardless, so CI must
+    ...    provision its own throwaway key or the pods hang in
+    ...    ContainerCreating forever waiting for a Secret that never exists.
+    kubectl apply     ./integration-tests/tests/00-setup/secret-config-keyring.yaml
+

--- a/tests/00-setup/secret-config-keyring.yaml
+++ b/tests/00-setup/secret-config-keyring.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: config-keyring
+  namespace: sdc-system
+  labels:
+    config.sdcio.dev/keyring: "true"
+type: Opaque
+stringData:
+  # CI-only placeholder key (same value as config-server's own placeholder
+  # sample, artifacts/in/secret_keyring.yaml). config-server intentionally
+  # stopped shipping a default keyring Secret in its own deploy artifacts
+  # (see sdcio/config-server commit 83d07f8, "added ENV keyring and removed
+  # keyring secret") so that real deployments are forced to provision their
+  # own key material instead of relying on a well-known default. The
+  # integration-tests cluster is not a real deployment, so it provisions its
+  # own throwaway key here.
+  keyring.json: '{"primary":"key-1","keys":{"key-1":"Fyap3X+pl8mYv2gV90sdmuy+YJ+FocFf5ygHGxZ+ws4="}}'


### PR DESCRIPTION
## Summary
- `sdcio/config-server` intentionally stopped shipping a default `config-keyring` Secret in its own deploy artifacts (commit `83d07f8`, "added ENV keyring and removed keyring secret") to force real deployments to bring their own key material, but the `data-server-controller` StatefulSet still mounts that Secret as a volume unconditionally.
- Without it, `kubectl apply`-ing config-server's generated `artifacts.yaml` produces a pod stuck in `ContainerCreating` for the full 10-minute Robot timeout with no clear error — this affects `sdcio/config-server` PR #441 (and every run since) and currently blocks `sdcio/data-server` PR #471 / `sdcio/config-server` PR #476.
- Adds a CI-only placeholder `config-keyring` Secret and applies it in `00-setup` right after `artifacts.yaml` (so the `sdc-system` namespace already exists) and before the suite waits for the StatefulSet to become ready.

## Test plan
- [x] `robot --dryrun` on `tests/00-setup/` passes (syntax-checked locally).
- [x] Manifest YAML validated (`python3 -c 'import yaml; yaml.safe_load(...)'`), placeholder key confirmed to decode to a valid 32-byte AES key matching `config-server`'s `pkg/keyring/keyring.go` requirements.
- [ ] Re-run `sdcio/config-server` PR #476's `integration-tests` job with `Pairs-with: sdcio/integration-tests#<this PR>` to confirm the StatefulSet comes up.

Made with [Cursor](https://cursor.com)